### PR TITLE
fix: adjust timeout duration for course fetching and improve error lo…

### DIFF
--- a/be-classlist/internal/biz/classer.go
+++ b/be-classlist/internal/biz/classer.go
@@ -70,7 +70,7 @@ func (cluc *ClassUsecase) GetClasses(ctx context.Context, stuID, year, semester 
 					wg.Done()
 				})
 			}
-			time.AfterFunc(10*time.Second, done)
+			time.AfterFunc(cluc.waitCrawTime, done)
 			defer done()
 
 			crawClassInfos_, crawScs, crawErr := cluc.getCourseFromCrawler(context.Background(), stuID, year, semester)
@@ -268,17 +268,15 @@ func (cluc *ClassUsecase) GetStuIdsByJxbId(ctx context.Context, jxbId string) ([
 }
 
 func (cluc *ClassUsecase) getCourseFromCrawler(ctx context.Context, stuID string, year string, semester string) ([]*model.ClassInfo, []*model.StudentCourse, error) {
-	////测试用的
-	//cookie := "JSESSIONID=77CCA81367438A56D3AFF46797E674A4"
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second) // 10秒超时,防止影响
-	defer cancel()                                                 // 确保在函数返回前取消上下文，防止资源泄漏
+	timeoutCtx, cancel := context.WithTimeout(ctx, 4*cluc.waitCrawTime) //防止影响
+	defer cancel()                                                      // 确保在函数返回前取消上下文，防止资源泄漏
 
 	getCookieStart := time.Now()
 
 	cookie, err := cluc.ccnu.GetCookie(timeoutCtx, stuID)
 	if err != nil {
-		cluc.log.Errorf("Error getting cookie(stu_id:%v) from other service", stuID)
+		cluc.log.Errorf("Error getting cookie(stu_id:%v) from other service: %v", stuID, err)
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
This pull request introduces changes to improve the flexibility and error handling of the `ClassUsecase` methods in the `be-classlist/internal/biz/classer.go` file. The most important updates include replacing hardcoded timeouts with a configurable parameter and enhancing logging for better error visibility.

### Improvements to timeout configuration:

* Replaced the hardcoded `10*time.Second` timeout in `GetClasses` with the configurable `cluc.waitCrawTime` to allow for dynamic timeout adjustments. (`[be-classlist/internal/biz/classer.goL73-R73](diffhunk://#diff-c466db638182e811e3161c4166b58591312d73ba3d5e237f0e223005cd8e0e72L73-R73)`)
* Updated the timeout context in `getCourseFromCrawler` to use `4*cluc.waitCrawTime` instead of the fixed `10*time.Second`, enabling more flexible timeout settings. (`[be-classlist/internal/biz/classer.goL271-R279](diffhunk://#diff-c466db638182e811e3161c4166b58591312d73ba3d5e237f0e223005cd8e0e72L271-R279)`)

### Enhancements to logging:

* Improved the error log in `getCourseFromCrawler` to include the error details when failing to retrieve a cookie, providing more context for debugging. (`[be-classlist/internal/biz/classer.goL271-R279](diffhunk://#diff-c466db638182e811e3161c4166b58591312d73ba3d5e237f0e223005cd8e0e72L271-R279)`)…gging