### PR TITLE
refactor: optimize BatchInsertOrUpdate by using composite keys for existing records lookup

### DIFF
--- a/be-grade/repository/dao/grade.go
+++ b/be-grade/repository/dao/grade.go
@@ -63,20 +63,29 @@ func (d *gradeDAO) BatchInsertOrUpdate(ctx context.Context, grades []model.Grade
 		return nil, nil
 	}
 
+	type pair struct {
+		StudentId string
+		JxbId     string
+	}
+	var pairs []pair
+
 	// 构造联合键并规格化 ID
-	ids := make([]string, len(grades))
 	for i := range grades {
 		grades[i].JxbId = normalizeJxbId(&grades[i])
-		ids[i] = grades[i].StudentId + grades[i].JxbId
+		pairs = append(pairs, pair{
+			StudentId: grades[i].StudentId,
+			JxbId:     grades[i].JxbId,
+		})
 	}
 
 	// 1. 查询已有记录用于比对
 	var existingGrades []model.Grade
+	// 取消 CONCAT 走索引
 	err = d.db.WithContext(ctx).
-		Where("CONCAT(student_id, jxb_id) IN ?", ids).
+		Where("(student_id, jxb_id) IN ?", pairs).
 		Find(&existingGrades).Error
 	if err != nil {
-		return nil, errorx.Errorf("dao: BatchInsertOrUpdate find existing records failed, count: %d, err: %w", len(ids), err)
+		return nil, errorx.Errorf("dao: BatchInsertOrUpdate find existing records failed, count: %d, err: %w", len(pairs), err)
 	}
 
 	existingMap := make(map[string]model.Grade)

--- a/be-grade/repository/dao/grade.go
+++ b/be-grade/repository/dao/grade.go
@@ -67,7 +67,7 @@ func (d *gradeDAO) BatchInsertOrUpdate(ctx context.Context, grades []model.Grade
 		StudentId string
 		JxbId     string
 	}
-	var pairs []pair
+	pairs := make([]pair, 0, len(grades))
 
 	// 构造联合键并规格化 ID
 	for i := range grades {

--- a/be-grade/repository/dao/grade.go
+++ b/be-grade/repository/dao/grade.go
@@ -63,29 +63,21 @@ func (d *gradeDAO) BatchInsertOrUpdate(ctx context.Context, grades []model.Grade
 		return nil, nil
 	}
 
-	type pair struct {
-		StudentId string
-		JxbId     string
-	}
-	pairs := make([]pair, 0, len(grades))
-
+	values := make([][]interface{}, 0, len(grades))
 	// 构造联合键并规格化 ID
 	for i := range grades {
 		grades[i].JxbId = normalizeJxbId(&grades[i])
-		pairs = append(pairs, pair{
-			StudentId: grades[i].StudentId,
-			JxbId:     grades[i].JxbId,
-		})
+		values = append(values, []interface{}{grades[i].StudentId, grades[i].JxbId})
 	}
 
 	// 1. 查询已有记录用于比对
 	var existingGrades []model.Grade
 	// 取消 CONCAT 走索引
 	err = d.db.WithContext(ctx).
-		Where("(student_id, jxb_id) IN ?", pairs).
+		Where("(student_id, jxb_id) IN ?", values).
 		Find(&existingGrades).Error
 	if err != nil {
-		return nil, errorx.Errorf("dao: BatchInsertOrUpdate find existing records failed, count: %d, err: %w", len(pairs), err)
+		return nil, errorx.Errorf("dao: BatchInsertOrUpdate find existing records failed, count: %d, err: %w", len(values), err)
 	}
 
 	existingMap := make(map[string]model.Grade)


### PR DESCRIPTION
This pull request improves the efficiency of the batch insert or update operation in the `gradeDAO` by changing how existing records are queried. Instead of concatenating keys and using `CONCAT`, it now uses a tuple comparison for indexed lookups.

**Database query optimization:**

* Replaced concatenated key lookup (`CONCAT(student_id, jxb_id) IN ...`) with tuple-based lookup (`(student_id, jxb_id) IN ...`) in the `BatchInsertOrUpdate` method of `gradeDAO`, allowing the query to use indexes and improving performance.
* Introduced a new `pair` struct to represent the composite key of `StudentId` and `JxbId`, and refactored the code to build a slice of these pairs for the query.