### PR TITLE
refractor:课表模块

### DIFF
--- a/be-classlist/biz/biz.go
+++ b/be-classlist/biz/biz.go
@@ -38,7 +38,7 @@ type ClassCrawler interface {
 
 type DelayQueue interface {
 	Send(ctx context.Context, key, value []byte) error
-	Consume(groupID string, f func(ctx context.Context, key []byte, value []byte)) error
+	Consume(groupID string, f func(ctx context.Context, key []byte, value []byte) error) error
 	Close()
 }
 

--- a/be-classlist/biz/biz.go
+++ b/be-classlist/biz/biz.go
@@ -38,7 +38,7 @@ type ClassCrawler interface {
 
 type DelayQueue interface {
 	Send(ctx context.Context, key, value []byte) error
-	Consume(groupID string, f func(ctx context.Context, key []byte, value []byte) error) error
+	Consume(groupID string, f func(ctx context.Context, key []byte, value []byte) (ack bool, err error)) error
 	Close()
 }
 

--- a/be-classlist/biz/errors.go
+++ b/be-classlist/biz/errors.go
@@ -23,7 +23,8 @@ var (
 	ErrCrawlerTemporary = errors.New("temporary class crawler failure")
 
 	// ErrCrawlerAuthentication 表示 Cookie 为空、被重定向到登录页或上游返回 401/403。
-	// 使用相同登录态重试不会恢复，所以该错误是永久错误，不应自动重试。
+	// 课表刷新每次尝试都会重新向用户服务获取并校验 Cookie，因此允许有界重试来恢复
+	// Cookie 校验与实际请求之间的失效竞态；用户服务直接返回的 Unauthenticated 仍不重试。
 	ErrCrawlerAuthentication = errors.New("class crawler authentication failed")
 
 	// ErrCrawlerProtocol 表示响应格式、字段、状态码或课表时间描述不符合当前协议。

--- a/be-classlist/biz/errors.go
+++ b/be-classlist/biz/errors.go
@@ -11,4 +11,37 @@ var (
 	ErrClassDeleteRejected   = errors.New("class delete rejected")
 	ErrClassUpdateRejected   = errors.New("class update rejected")
 	ErrGetStuIDsByJxbID      = errors.New("get student ids by jxb id failed")
+
+	// ErrClassRefreshPending 表示另一个刷新任务在请求等待预算内仍未完成。
+	// 它描述“暂时没有可返回结果”，只用于同步查询返回，不会据此创建新的异步重试消息。
+	ErrClassRefreshPending = errors.New("class refresh is still pending")
+
+	// ErrRefreshPersistence 表示刷新流水线写入刷新日志、课程快照或清理冲突课程失败。
+	ErrRefreshPersistence = errors.New("class refresh persistence failed")
+
+	// ErrCrawlerTemporary 表示上游明确返回的临时故障，例如 408/425/429 或 5xx。
+	ErrCrawlerTemporary = errors.New("temporary class crawler failure")
+
+	// ErrCrawlerAuthentication 表示 Cookie 为空、被重定向到登录页或上游返回 401/403。
+	// 使用相同登录态重试不会恢复，所以该错误是永久错误，不应自动重试。
+	ErrCrawlerAuthentication = errors.New("class crawler authentication failed")
+
+	// ErrCrawlerProtocol 表示响应格式、字段、状态码或课表时间描述不符合当前协议。
+	// 这通常意味着上游接口变化或程序解析规则过期，重复请求不会修复，应停止重试并保留根因。
+	ErrCrawlerProtocol = errors.New("class crawler protocol failed")
+
+	// ErrCrawlerEmptyResult 表示上游调用成功，但没有得到当前业务所要求的课程和选课关系。
+	// 它作为不可重试的业务/协议异常，避免持续请求学校系统。
+	ErrCrawlerEmptyResult = errors.New("class crawler returned empty result")
+
+	// ErrCookieUnavailable 表示用户服务成功响应却没有可用响应对象或 Cookie。
+	// 这不是传输瞬时错误；若用户服务返回了 gRPC 错误，则保留原错误并由 gRPC code 决定是否重试。
+	ErrCookieUnavailable = errors.New("user cookie is unavailable")
+
+	// ErrUnsupportedStudentType 表示学号无法映射到当前支持的本科生或研究生爬虫。
+	// 输入不变时重试结果也不会改变，因此它是不可重试错误。
+	ErrUnsupportedStudentType = errors.New("unsupported student type")
+
+	// ErrRefreshInvariant 表示刷新代码违反内部不变量，例如 singleflight 返回了错误类型。
+	ErrRefreshInvariant = errors.New("class refresh invariant violated")
 )

--- a/be-classlist/biz/usecase/classer.go
+++ b/be-classlist/biz/usecase/classer.go
@@ -75,7 +75,7 @@ func (cluc *ClassUsecase) GetClasses(ctx context.Context, stuID, year, semester 
 
 	// 希望首次爬虫时间更长
 	if localLastRefreshTime == nil {
-		waitCrawTime = max(waitCrawTime, 15*time.Second)
+		waitCrawTime = max(waitCrawTime, defaultRefreshJobTimeout)
 	}
 
 	// 2. 状态检查，决定从哪里获取课程数据

--- a/be-classlist/biz/usecase/classer.go
+++ b/be-classlist/biz/usecase/classer.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -71,6 +72,9 @@ func (cluc *ClassUsecase) GetClasses(ctx context.Context, stuID, year, semester 
 	localClasses, localLastRefreshTime, localErr := cluc.loadLocal(ctx, stuID, year, semester)
 	if localErr != nil {
 		logh.Errorf("load local failed: %+v", localErr)
+		if !errors.Is(localErr, biz.ErrClassNotFound) {
+			return nil, nil, localErr
+		}
 	}
 
 	// 希望首次爬虫时间更长
@@ -83,6 +87,9 @@ func (cluc *ClassUsecase) GetClasses(ctx context.Context, stuID, year, semester 
 
 	if action == model.ActionReturnLocal {
 		if len(localClasses) == 0 {
+			if refreshLog != nil && refreshLog.IsReady() && errors.Is(localErr, biz.ErrClassNotFound) {
+				return make([]*model.ClassInfoBO, 0), &refreshLog.UpdatedAt, nil
+			}
 			if localErr != nil {
 				return nil, nil, localErr
 			}
@@ -127,9 +134,7 @@ func (cluc *ClassUsecase) GetClasses(ctx context.Context, stuID, year, semester 
 		// 若时间超过一秒或获取爬虫失败
 	}
 	logh.Infof("start crawl, waitCrawTime=%v", waitCrawTime)
-	requestKey := fmt.Sprintf("craw:%s:%s:%s", stuID, year, semester)
-
-	res, err := cluc.doCrawlWithSingleflight(ctx, requestKey, stuID, year, semester, waitCrawTime)
+	res, err := cluc.doCrawlWithSingleflight(ctx, stuID, year, semester, waitCrawTime)
 	if err == nil && res != nil {
 		return res, &currentTime, nil
 	}

--- a/be-classlist/biz/usecase/classer.go
+++ b/be-classlist/biz/usecase/classer.go
@@ -82,6 +82,12 @@ func (cluc *ClassUsecase) GetClasses(ctx context.Context, stuID, year, semester 
 	action, refreshLog, waitBudget := cluc.decideRefreshAction(ctx, stuID, year, semester, refresh, localErr, refreshInterval, waitCrawTime)
 
 	if action == model.ActionReturnLocal {
+		if len(localClasses) == 0 {
+			if localErr != nil {
+				return nil, nil, localErr
+			}
+			return nil, nil, errorx.Errorf("usecase.class.GetClasses: local snapshot is empty: %w", biz.ErrClassNotFound)
+		}
 		logh.Infof("return local classes, last_refresh=%v", localLastRefreshTime)
 		return localClasses, localLastRefreshTime, nil
 	}
@@ -96,7 +102,10 @@ func (cluc *ClassUsecase) GetClasses(ctx context.Context, stuID, year, semester 
 			newLocalClassInfo, err := cluc.classRepo.GetClassesFromLocal(ctx, stuID, year, semester)
 			if err != nil {
 				logh.Errorf("fetch class from local failed: %+v", err)
-				return localClasses, localLastRefreshTime, nil
+				if len(localClasses) > 0 {
+					return localClasses, localLastRefreshTime, nil
+				}
+				return nil, nil, err
 			}
 			return newLocalClassInfo, &readyLog.UpdatedAt, nil
 		}
@@ -106,7 +115,13 @@ func (cluc *ClassUsecase) GetClasses(ctx context.Context, stuID, year, semester 
 		// 反之就得返回了
 		if waited >= 1*time.Second {
 			logh.Warnf("pending wait timeout, waited=%v, fallback to local", waited)
-			return localClasses, localLastRefreshTime, nil
+			if len(localClasses) > 0 {
+				return localClasses, localLastRefreshTime, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return nil, nil, err
+			}
+			return nil, nil, fmt.Errorf("%w after %v", biz.ErrClassRefreshPending, waited)
 		}
 
 		// 若时间超过一秒或获取爬虫失败
@@ -114,7 +129,7 @@ func (cluc *ClassUsecase) GetClasses(ctx context.Context, stuID, year, semester 
 	logh.Infof("start crawl, waitCrawTime=%v", waitCrawTime)
 	requestKey := fmt.Sprintf("craw:%s:%s:%s", stuID, year, semester)
 
-	res, err := cluc.doCrawlWithSingleflight(ctx, requestKey, stuID, year, semester, localClasses, currentTime)
+	res, err := cluc.doCrawlWithSingleflight(ctx, requestKey, stuID, year, semester, waitCrawTime)
 	if err == nil && res != nil {
 		return res, &currentTime, nil
 	}
@@ -122,7 +137,13 @@ func (cluc *ClassUsecase) GetClasses(ctx context.Context, stuID, year, semester 
 		logh.Errorf("crawl failed: %+v", err)
 	}
 
-	return localClasses, localLastRefreshTime, nil
+	if len(localClasses) > 0 {
+		return localClasses, localLastRefreshTime, nil
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	return nil, nil, fmt.Errorf("%w: refresh returned no data", biz.ErrRefreshInvariant)
 }
 
 func (cluc *ClassUsecase) AddClass(ctx context.Context, stuID string, info *model.ClassInfoBO) error {

--- a/be-classlist/biz/usecase/classer_helpers.go
+++ b/be-classlist/biz/usecase/classer_helpers.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"time"
 
 	"github.com/asynccnu/ccnubox-be/be-classlist/biz"
@@ -73,7 +75,7 @@ func (cluc *ClassUsecase) decideRefreshAction(ctx context.Context, stuID, year, 
 
 		// 刷新已完成
 		// 从本地拿课程
-		if latestLog.IsReady() {
+		if latestLog.IsReady() && localErr == nil {
 			return model.ActionReturnLocal, latestLog, 0
 		}
 
@@ -220,26 +222,46 @@ func (cluc *ClassUsecase) filterAddedClassesConflictingWithOfficial(ctx context.
 	return kept, conflictIDs
 }
 
-// 包一层 singleflight + crawClass 调用 + 超时处理
-func (cluc *ClassUsecase) doCrawlWithSingleflight(ctx context.Context, key string, stuID, year, semester string, local []*model.ClassInfoBO, logTime time.Time) ([]*model.ClassInfoBO, error) {
-	v, err, _ := cluc.sfGroup.Do(key, func() (interface{}, error) {
-		res, err := cluc.crawMergedClass(ctx, stuID, year, semester, logTime, local, true)
+// 合并同一课表的并发刷新。调用者只控制自己的等待；共享任务不会被首个调用者取消。
+func (cluc *ClassUsecase) doCrawlWithSingleflight(ctx context.Context, key string, stuID, year, semester string, jobTimeout time.Duration) ([]*model.ClassInfoBO, error) {
+	return cluc.doCrawlAttemptWithSingleflight(ctx, key, stuID, year, semester, 0, maxRefreshRetryAttempts, jobTimeout)
+}
+
+func (cluc *ClassUsecase) doCrawlAttemptWithSingleflight(ctx context.Context, key string, stuID, year, semester string, attempt, maxAttempts int, jobTimeout time.Duration) ([]*model.ClassInfoBO, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if jobTimeout <= 0 {
+		jobTimeout = defaultRefreshJobTimeout
+	}
+	resultCh := cluc.sfGroup.DoChan(key, func() (interface{}, error) {
+		jobCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), jobTimeout)
+		defer cancel()
+		res, err := cluc.crawlOnce(jobCtx, stuID, year, semester)
 		if err != nil {
+			cluc.coordinateRefreshRetry(jobCtx, stuID, year, semester, attempt, maxAttempts, err)
 			return nil, err
 		}
 		if res == nil {
-			return nil, fmt.Errorf("crawler returned empty result")
+			return nil, fmt.Errorf("%w: crawler returned nil result", biz.ErrRefreshInvariant)
 		}
 		return res, nil
 	})
 
-	if err != nil {
-		return nil, err
+	var result singleflight.Result
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result = <-resultCh:
 	}
 
-	res, ok := v.([]*model.ClassInfoBO)
+	if result.Err != nil {
+		return nil, result.Err
+	}
+
+	res, ok := result.Val.([]*model.ClassInfoBO)
 	if !ok {
-		return nil, fmt.Errorf("crawler returned unexpected result type")
+		return nil, fmt.Errorf("%w: crawler returned unexpected result type %T", biz.ErrRefreshInvariant, result.Val)
 	}
 	return res, nil
 }

--- a/be-classlist/biz/usecase/classer_helpers.go
+++ b/be-classlist/biz/usecase/classer_helpers.go
@@ -228,8 +228,10 @@ func (cluc *ClassUsecase) filterAddedClassesConflictingWithOfficial(ctx context.
 }
 
 // 合并同一课表的并发刷新。调用者只控制自己的等待；共享任务不会被首个调用者取消。
-func classRefreshSingleflightKey(stuID, year, semester string) string {
-	return fmt.Sprintf("craw:%s:%s:%s", stuID, year, semester)
+func classRefreshSingleflightKey(stuID, year, semester string, attempt, maxAttempts int) string {
+	// attempt 会影响失败后的重试调度，不能让不同重试阶段共享同一个闭包。
+	// 否则重试消息可能合入 attempt=0 的普通刷新并把计数重置为 1。
+	return fmt.Sprintf("craw:%s:%s:%s:attempt:%d:max:%d", stuID, year, semester, attempt, maxAttempts)
 }
 
 func (cluc *ClassUsecase) doCrawlWithSingleflight(ctx context.Context, stuID, year, semester string, jobTimeout time.Duration) ([]*model.ClassInfoBO, error) {

--- a/be-classlist/biz/usecase/classer_helpers.go
+++ b/be-classlist/biz/usecase/classer_helpers.go
@@ -15,6 +15,9 @@ import (
 	"github.com/asynccnu/ccnubox-be/common/pkg/errorx"
 	"github.com/asynccnu/ccnubox-be/common/pkg/logger"
 	"github.com/asynccnu/ccnubox-be/common/tool"
+	"golang.org/x/sync/singleflight"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -266,6 +269,15 @@ func (cluc *ClassUsecase) doCrawlAttemptWithSingleflight(ctx context.Context, ke
 	return res, nil
 }
 
+// crawlOnce 只执行一次刷新；重试策略由调用方统一协调。
+func (cluc *ClassUsecase) crawlOnce(ctx context.Context, stuID, year, semester string) ([]*model.ClassInfoBO, error) {
+	local, _, err := cluc.loadLocal(ctx, stuID, year, semester)
+	if err != nil && !errors.Is(err, biz.ErrClassNotFound) {
+		cluc.log.WithContext(ctx).Warnf("load local metadata before refresh failed: %+v", err)
+	}
+	return cluc.crawMergedClass(ctx, stuID, year, semester, time.Now(), local, true)
+}
+
 // 爬取课表并合并自写课程
 func (cluc *ClassUsecase) crawMergedClass(ctx context.Context, stuID, year, semester string, logTime time.Time, localClassInfo []*model.ClassInfoBO, mergeAdd bool) ([]*model.ClassInfoBO, error) {
 	logh := cluc.log.WithContext(ctx)
@@ -278,15 +290,13 @@ func (cluc *ClassUsecase) crawMergedClass(ctx context.Context, stuID, year, seme
 	// 插入刷新日志
 	logID, err := cluc.refreshLogRepo.InsertRefreshLog(ctx, stuID, year, semester, model.Pending, logTime)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: insert refresh log: %w", biz.ErrRefreshPersistence, err)
 	}
 
 	// 执行爬虫
 	crawClassInfos, crawScs, _, err := cluc.getCourseFromCrawler(ctx, stuID, year, semester)
 	if err != nil {
 		_ = cluc.refreshLogRepo.UpdateRefreshLogStatus(ctx, logID, model.Failed)
-		// 重试
-		_ = cluc.sendRetryMsg(ctx, stuID, year, semester)
 		return nil, err
 	}
 
@@ -315,8 +325,7 @@ func (cluc *ClassUsecase) crawMergedClass(ctx context.Context, stuID, year, seme
 	err = cluc.classRepo.SaveClass(ctx, stuID, year, semester, crawClassInfos, crawScs)
 	if err != nil {
 		_ = cluc.refreshLogRepo.UpdateRefreshLogStatus(ctx, logID, model.Failed)
-		_ = cluc.sendRetryMsg(ctx, stuID, year, semester)
-		return nil, err
+		return nil, fmt.Errorf("%w: save class snapshot: %w", biz.ErrRefreshPersistence, err)
 	}
 
 	if !mergeAdd {
@@ -336,8 +345,7 @@ func (cluc *ClassUsecase) crawMergedClass(ctx context.Context, stuID, year, seme
 		err := cluc.classRepo.DeleteAddedClasses(ctx, stuID, year, semester, conflictAddedIDs)
 		if err != nil {
 			_ = cluc.refreshLogRepo.UpdateRefreshLogStatus(ctx, logID, model.Failed)
-			_ = cluc.sendRetryMsg(ctx, stuID, year, semester)
-			return nil, err
+			return nil, fmt.Errorf("%w: delete conflicting added classes: %w", biz.ErrRefreshPersistence, err)
 		}
 	}
 
@@ -376,7 +384,7 @@ func (cluc *ClassUsecase) getCourseFromCrawler(ctx context.Context, stuID string
 	if len(cookie) == 0 {
 		crawSuccess = false
 		logh.Error(fmt.Sprintf("the cookie from other service is empty for stu_id:%v", stuID))
-		return nil, nil, -1, fmt.Errorf("the cookie from other service is empty for stu_id:%v", stuID)
+		return nil, nil, -1, fmt.Errorf("%w: empty cookie for stu_id=%s", biz.ErrCrawlerAuthentication, stuID)
 	}
 
 	var stu biz.Student
@@ -388,7 +396,7 @@ func (cluc *ClassUsecase) getCourseFromCrawler(ctx context.Context, stuID string
 	case tool.PostGraduate:
 		stu = &biz.GraduateStudent{}
 	default:
-		return nil, nil, -1, fmt.Errorf("the type of student isn't undergraduate")
+		return nil, nil, -1, fmt.Errorf("%w: stu_id=%s", biz.ErrUnsupportedStudentType, stuID)
 	}
 
 	ci, sc, sum, err := func() ([]*model.ClassInfoBO, []*model.StudentCourseBO, int, error) {
@@ -402,7 +410,7 @@ func (cluc *ClassUsecase) getCourseFromCrawler(ctx context.Context, stuID string
 			return nil, nil, -1, err
 		}
 		if len(classinfos) == 0 || len(scs) == 0 {
-			return nil, nil, -1, errors.New("no classinfos or scs found")
+			return nil, nil, -1, fmt.Errorf("%w: no classinfos or student-course relations found", biz.ErrCrawlerEmptyResult)
 		}
 		return classinfos, scs, sum, nil
 	}()
@@ -440,6 +448,82 @@ func (cluc *ClassUsecase) sendRetryMsg(ctx context.Context, stuID, year, semeste
 	return err
 }
 
+func (cluc *ClassUsecase) coordinateRefreshRetry(ctx context.Context, stuID, year, semester string, attempt, maxAttempts int, cause error) {
+	logh := cluc.log.WithContext(ctx)
+	if !shouldRetryClassRefresh(cause) {
+		logh.Warn("class refresh failure is not retryable",
+			logger.String("stu_id", stuID),
+			logger.String("year", year),
+			logger.String("semester", semester),
+			logger.Int("attempt", attempt),
+			logger.Error(cause),
+		)
+		return
+	}
+	if attempt >= maxAttempts {
+		// crawMergedClass 已将本次刷新日志持久化为 Failed；此处明确结束重试链。
+		logh.Error("class refresh retries exhausted",
+			logger.String("stu_id", stuID),
+			logger.String("year", year),
+			logger.String("semester", semester),
+			logger.Int("attempt", attempt),
+			logger.Int("max_attempts", maxAttempts),
+			logger.Error(cause),
+		)
+		return
+	}
+
+	nextAttempt := attempt + 1
+	// 刷新失败经常意味着 jobCtx 已到 deadline。发布下一条消息必须脱离该取消信号
+	publishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), retryPublishTimeout)
+	defer cancel()
+	if err := cluc.sendRetryMsg(publishCtx, stuID, year, semester, nextAttempt, maxAttempts); err != nil {
+		logh.Error("schedule class refresh retry failed",
+			logger.String("stu_id", stuID),
+			logger.String("year", year),
+			logger.String("semester", semester),
+			logger.Int("attempt", nextAttempt),
+			logger.Int("max_attempts", maxAttempts),
+			logger.Error(err),
+		)
+	}
+}
+
+// 错误白名单，确定是否需要重试
+func shouldRetryClassRefresh(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+
+	if errors.Is(err, biz.ErrCrawlerAuthentication) ||
+		errors.Is(err, biz.ErrCrawlerProtocol) ||
+		errors.Is(err, biz.ErrCrawlerEmptyResult) ||
+		errors.Is(err, biz.ErrCookieUnavailable) ||
+		errors.Is(err, biz.ErrUnsupportedStudentType) ||
+		errors.Is(err, biz.ErrRefreshInvariant) ||
+		errors.Is(err, biz.ErrInvalidParam) {
+		return false
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, biz.ErrCrawlerTemporary) ||
+		errors.Is(err, biz.ErrRefreshPersistence) ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	switch status.Code(err) {
+	case codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted, codes.Unavailable:
+		return true
+	case codes.Canceled, codes.InvalidArgument, codes.NotFound, codes.PermissionDenied, codes.Unauthenticated:
+		return false
+	}
+
+	var netErr net.Error
+	return errors.As(err, &netErr) && (netErr.Timeout() || netErr.Temporary())
+}
+
 func (cluc *ClassUsecase) startRetryConsumer() {
 	if cluc.delayQue == nil {
 		return
@@ -464,14 +548,35 @@ func (cluc *ClassUsecase) handleRetryMessage(ctx context.Context, _ []byte, valu
 		logh.Errorf("invalid refresh retry msg: value=%s", string(value))
 		return
 	}
-
-	logh.Infof("consume refresh retry msg stu_id=%s year=%s semester=%s", retryInfo.StuID, retryInfo.Year, retryInfo.Semester)
-	_, _, err := cluc.GetClasses(ctx, retryInfo.StuID, retryInfo.Year, retryInfo.Semester, true)
-	if err != nil {
-		logh.Errorf("handle refresh retry msg failed stu_id=%s year=%s semester=%s: %+v", retryInfo.StuID, retryInfo.Year, retryInfo.Semester, err)
+	if retryInfo.Version != 0 && retryInfo.Version != refreshRetryMessageVersion {
+		logh.Errorf("unsupported refresh retry msg version: value=%s", string(value))
 		return
 	}
-	logh.Infof("handle refresh retry msg handled stu_id=%s year=%s semester=%s", retryInfo.StuID, retryInfo.Year, retryInfo.Semester)
+	// 兼容升级前已经在 Kafka 中、尚未消费的无 attempt 消息。
+	if retryInfo.Attempt == 0 {
+		retryInfo.Attempt = 1
+	}
+	if retryInfo.MaxAttempts <= 0 || retryInfo.MaxAttempts > maxRefreshRetryAttempts {
+		retryInfo.MaxAttempts = maxRefreshRetryAttempts
+	}
+	if retryInfo.Attempt < 1 || retryInfo.Attempt > retryInfo.MaxAttempts {
+		logh.Errorf("invalid refresh retry attempt: attempt=%d max_attempts=%d value=%s", retryInfo.Attempt, retryInfo.MaxAttempts, string(value))
+		return
+	}
+
+	logh.Infof("consume refresh retry msg stu_id=%s year=%s semester=%s attempt=%d max_attempts=%d", retryInfo.StuID, retryInfo.Year, retryInfo.Semester, retryInfo.Attempt, retryInfo.MaxAttempts)
+	retryKey := fmt.Sprintf("retry:craw:%s:%s:%s:%d", retryInfo.StuID, retryInfo.Year, retryInfo.Semester, retryInfo.Attempt)
+	retryJobTimeout := defaultRefreshJobTimeout
+	if cluc.conf != nil && cluc.conf.ClassListConf != nil {
+		configuredTimeout := time.Duration(cluc.conf.ClassListConf.WaitCrawTime) * time.Millisecond
+		retryJobTimeout = max(retryJobTimeout, configuredTimeout)
+	}
+	_, err := cluc.doCrawlAttemptWithSingleflight(ctx, retryKey, retryInfo.StuID, retryInfo.Year, retryInfo.Semester, retryInfo.Attempt, retryInfo.MaxAttempts, retryJobTimeout)
+	if err != nil {
+		logh.Errorf("handle refresh retry msg failed stu_id=%s year=%s semester=%s attempt=%d max_attempts=%d: %+v", retryInfo.StuID, retryInfo.Year, retryInfo.Semester, retryInfo.Attempt, retryInfo.MaxAttempts, err)
+		return
+	}
+	logh.Infof("handle refresh retry msg succeeded stu_id=%s year=%s semester=%s attempt=%d", retryInfo.StuID, retryInfo.Year, retryInfo.Semester, retryInfo.Attempt)
 }
 
 func extractJxb(infos []*model.ClassInfoBO) []string {

--- a/be-classlist/biz/usecase/classer_helpers.go
+++ b/be-classlist/biz/usecase/classer_helpers.go
@@ -595,8 +595,7 @@ func (cluc *ClassUsecase) startRetryConsumer() {
 func decodeRefreshRetryMessage(value []byte) (refreshRetryMessage, error) {
 	var retryInfo refreshRetryMessage
 	if err := json.Unmarshal(value, &retryInfo); err != nil {
-		logh.Errorf("unmarshal refresh retry msg failed: value=%s, err=%+v", string(value), err)
-		return fmt.Errorf("unmarshal refresh retry message: %w", err)
+		return refreshRetryMessage{}, fmt.Errorf("unmarshal refresh retry message: %w", err)
 	}
 	if retryInfo.StuID == "" || retryInfo.Year == "" || retryInfo.Semester == "" {
 		return refreshRetryMessage{}, errors.New("invalid refresh retry message: missing required field")

--- a/be-classlist/biz/usecase/classer_helpers.go
+++ b/be-classlist/biz/usecase/classer_helpers.go
@@ -15,17 +15,19 @@ import (
 	"github.com/asynccnu/ccnubox-be/common/pkg/errorx"
 	"github.com/asynccnu/ccnubox-be/common/pkg/logger"
 	"github.com/asynccnu/ccnubox-be/common/tool"
+	"github.com/go-sql-driver/mysql"
 	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 const (
-	refreshRetryConsumerGroup  = "be-classlist-refresh-retry-worker"
+	refreshRetryConsumerGroup  = "be-classlist-refresh-retry-worker-v1"
 	refreshRetryMessageVersion = 1
 	maxRefreshRetryAttempts    = 3
 	defaultRefreshJobTimeout   = 15 * time.Second
 	retryPublishTimeout        = 5 * time.Second
+	refreshStatusUpdateTimeout = 2 * time.Second
 )
 
 type refreshRetryMessage struct {
@@ -78,7 +80,7 @@ func (cluc *ClassUsecase) decideRefreshAction(ctx context.Context, stuID, year, 
 
 		// 刷新已完成
 		// 从本地拿课程
-		if latestLog.IsReady() && localErr == nil {
+		if latestLog.IsReady() && (localErr == nil || errors.Is(localErr, biz.ErrClassNotFound)) {
 			return model.ActionReturnLocal, latestLog, 0
 		}
 
@@ -226,17 +228,22 @@ func (cluc *ClassUsecase) filterAddedClassesConflictingWithOfficial(ctx context.
 }
 
 // 合并同一课表的并发刷新。调用者只控制自己的等待；共享任务不会被首个调用者取消。
-func (cluc *ClassUsecase) doCrawlWithSingleflight(ctx context.Context, key string, stuID, year, semester string, jobTimeout time.Duration) ([]*model.ClassInfoBO, error) {
-	return cluc.doCrawlAttemptWithSingleflight(ctx, key, stuID, year, semester, 0, maxRefreshRetryAttempts, jobTimeout)
+func classRefreshSingleflightKey(stuID, year, semester string) string {
+	return fmt.Sprintf("craw:%s:%s:%s", stuID, year, semester)
 }
 
-func (cluc *ClassUsecase) doCrawlAttemptWithSingleflight(ctx context.Context, key string, stuID, year, semester string, attempt, maxAttempts int, jobTimeout time.Duration) ([]*model.ClassInfoBO, error) {
+func (cluc *ClassUsecase) doCrawlWithSingleflight(ctx context.Context, stuID, year, semester string, jobTimeout time.Duration) ([]*model.ClassInfoBO, error) {
+	return cluc.doCrawlAttemptWithSingleflight(ctx, stuID, year, semester, 0, maxRefreshRetryAttempts, jobTimeout)
+}
+
+func (cluc *ClassUsecase) doCrawlAttemptWithSingleflight(ctx context.Context, stuID, year, semester string, attempt, maxAttempts int, jobTimeout time.Duration) ([]*model.ClassInfoBO, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	if jobTimeout <= 0 {
 		jobTimeout = defaultRefreshJobTimeout
 	}
+	key := classRefreshSingleflightKey(stuID, year, semester)
 	resultCh := cluc.sfGroup.DoChan(key, func() (interface{}, error) {
 		jobCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), jobTimeout)
 		defer cancel()
@@ -269,6 +276,20 @@ func (cluc *ClassUsecase) doCrawlAttemptWithSingleflight(ctx context.Context, ke
 	return res, nil
 }
 
+func (cluc *ClassUsecase) updateRefreshLogStatus(ctx context.Context, logID uint64, status string) error {
+	statusCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), refreshStatusUpdateTimeout)
+	defer cancel()
+	if err := cluc.refreshLogRepo.UpdateRefreshLogStatus(statusCtx, logID, status); err != nil {
+		cluc.log.WithContext(statusCtx).Error("update class refresh log status failed",
+			logger.Int64("log_id", int64(logID)),
+			logger.String("status", status),
+			logger.Error(err),
+		)
+		return err
+	}
+	return nil
+}
+
 // crawlOnce 只执行一次刷新；重试策略由调用方统一协调。
 func (cluc *ClassUsecase) crawlOnce(ctx context.Context, stuID, year, semester string) ([]*model.ClassInfoBO, error) {
 	local, _, err := cluc.loadLocal(ctx, stuID, year, semester)
@@ -296,7 +317,9 @@ func (cluc *ClassUsecase) crawMergedClass(ctx context.Context, stuID, year, seme
 	// 执行爬虫
 	crawClassInfos, crawScs, _, err := cluc.getCourseFromCrawler(ctx, stuID, year, semester)
 	if err != nil {
-		_ = cluc.refreshLogRepo.UpdateRefreshLogStatus(ctx, logID, model.Failed)
+		if statusErr := cluc.updateRefreshLogStatus(ctx, logID, model.Failed); statusErr != nil {
+			return nil, errors.Join(err, fmt.Errorf("%w: mark refresh failed: %w", biz.ErrRefreshPersistence, statusErr))
+		}
 		return nil, err
 	}
 
@@ -324,12 +347,17 @@ func (cluc *ClassUsecase) crawMergedClass(ctx context.Context, stuID, year, seme
 	jxbIDs := extractJxb(crawClassInfos)
 	err = cluc.classRepo.SaveClass(ctx, stuID, year, semester, crawClassInfos, crawScs)
 	if err != nil {
-		_ = cluc.refreshLogRepo.UpdateRefreshLogStatus(ctx, logID, model.Failed)
-		return nil, fmt.Errorf("%w: save class snapshot: %w", biz.ErrRefreshPersistence, err)
+		refreshErr := fmt.Errorf("%w: save class snapshot: %w", biz.ErrRefreshPersistence, err)
+		if statusErr := cluc.updateRefreshLogStatus(ctx, logID, model.Failed); statusErr != nil {
+			return nil, errors.Join(refreshErr, fmt.Errorf("%w: mark refresh failed: %w", biz.ErrRefreshPersistence, statusErr))
+		}
+		return nil, refreshErr
 	}
 
 	if !mergeAdd {
-		_ = cluc.refreshLogRepo.UpdateRefreshLogStatus(ctx, logID, model.Ready)
+		if err := cluc.updateRefreshLogStatus(ctx, logID, model.Ready); err != nil {
+			return nil, fmt.Errorf("%w: mark refresh ready: %w", biz.ErrRefreshPersistence, err)
+		}
 		_ = cluc.jxbRepo.SaveJxb(ctx, stuID, jxbIDs)
 		return crawClassInfos, nil
 	}
@@ -344,12 +372,17 @@ func (cluc *ClassUsecase) crawMergedClass(ctx context.Context, stuID, year, seme
 	if len(conflictAddedIDs) > 0 {
 		err := cluc.classRepo.DeleteAddedClasses(ctx, stuID, year, semester, conflictAddedIDs)
 		if err != nil {
-			_ = cluc.refreshLogRepo.UpdateRefreshLogStatus(ctx, logID, model.Failed)
-			return nil, fmt.Errorf("%w: delete conflicting added classes: %w", biz.ErrRefreshPersistence, err)
+			refreshErr := fmt.Errorf("%w: delete conflicting added classes: %w", biz.ErrRefreshPersistence, err)
+			if statusErr := cluc.updateRefreshLogStatus(ctx, logID, model.Failed); statusErr != nil {
+				return nil, errors.Join(refreshErr, fmt.Errorf("%w: mark refresh failed: %w", biz.ErrRefreshPersistence, statusErr))
+			}
+			return nil, refreshErr
 		}
 	}
 
-	_ = cluc.refreshLogRepo.UpdateRefreshLogStatus(ctx, logID, model.Ready)
+	if err := cluc.updateRefreshLogStatus(ctx, logID, model.Ready); err != nil {
+		return nil, fmt.Errorf("%w: mark refresh ready: %w", biz.ErrRefreshPersistence, err)
+	}
 	_ = cluc.jxbRepo.SaveJxb(ctx, stuID, jxbIDs)
 
 	crawClassInfos = append(crawClassInfos, addedInfos...)
@@ -396,6 +429,7 @@ func (cluc *ClassUsecase) getCourseFromCrawler(ctx context.Context, stuID string
 	case tool.PostGraduate:
 		stu = &biz.GraduateStudent{}
 	default:
+		crawSuccess = false
 		return nil, nil, -1, fmt.Errorf("%w: stu_id=%s", biz.ErrUnsupportedStudentType, stuID)
 	}
 
@@ -409,8 +443,11 @@ func (cluc *ClassUsecase) getCourseFromCrawler(ctx context.Context, stuID string
 			logh.Errorf("craw classlist stu_id=%s year=%s semester=%s failed: %+v", stuID, year, semester, err)
 			return nil, nil, -1, err
 		}
+		if len(classinfos) == 0 && len(scs) == 0 {
+			return make([]*model.ClassInfoBO, 0), make([]*model.StudentCourseBO, 0), sum, nil
+		}
 		if len(classinfos) == 0 || len(scs) == 0 {
-			return nil, nil, -1, fmt.Errorf("%w: no classinfos or student-course relations found", biz.ErrCrawlerEmptyResult)
+			return nil, nil, -1, fmt.Errorf("%w: inconsistent class and student-course results", biz.ErrCrawlerProtocol)
 		}
 		return classinfos, scs, sum, nil
 	}()
@@ -461,7 +498,7 @@ func (cluc *ClassUsecase) coordinateRefreshRetry(ctx context.Context, stuID, yea
 		return
 	}
 	if attempt >= maxAttempts {
-		// crawMergedClass 已将本次刷新日志持久化为 Failed；此处明确结束重试链。
+		// 超过最大重试，打日志
 		logh.Error("class refresh retries exhausted",
 			logger.String("stu_id", stuID),
 			logger.String("year", year),
@@ -505,9 +542,21 @@ func shouldRetryClassRefresh(err error) bool {
 		return false
 	}
 
+	if errors.Is(err, biz.ErrRefreshPersistence) {
+		var mysqlErr *mysql.MySQLError
+		if !errors.As(err, &mysqlErr) {
+			return false
+		}
+		switch mysqlErr.Number {
+		case 1205, 1213, 2006, 2013:
+			return true
+		default:
+			return false
+		}
+	}
+
 	if errors.Is(err, context.DeadlineExceeded) ||
 		errors.Is(err, biz.ErrCrawlerTemporary) ||
-		errors.Is(err, biz.ErrRefreshPersistence) ||
 		errors.Is(err, io.EOF) ||
 		errors.Is(err, io.ErrUnexpectedEOF) {
 		return true
@@ -542,7 +591,7 @@ func (cluc *ClassUsecase) handleRetryMessage(ctx context.Context, _ []byte, valu
 	var retryInfo refreshRetryMessage
 	if err := json.Unmarshal(value, &retryInfo); err != nil {
 		logh.Errorf("unmarshal refresh retry msg failed: value=%s, err=%+v", string(value), err)
-		return
+		return fmt.Errorf("unmarshal refresh retry message: %w", err)
 	}
 	if retryInfo.StuID == "" || retryInfo.Year == "" || retryInfo.Semester == "" {
 		logh.Errorf("invalid refresh retry msg: value=%s", string(value))
@@ -561,7 +610,6 @@ func (cluc *ClassUsecase) handleRetryMessage(ctx context.Context, _ []byte, valu
 	}
 
 	logh.Infof("consume refresh retry msg stu_id=%s year=%s semester=%s attempt=%d max_attempts=%d", retryInfo.StuID, retryInfo.Year, retryInfo.Semester, retryInfo.Attempt, retryInfo.MaxAttempts)
-	retryKey := fmt.Sprintf("retry:craw:%s:%s:%s:%d", retryInfo.StuID, retryInfo.Year, retryInfo.Semester, retryInfo.Attempt)
 	retryJobTimeout := defaultRefreshJobTimeout
 	if cluc.conf != nil && cluc.conf.ClassListConf != nil {
 		configuredTimeout := time.Duration(cluc.conf.ClassListConf.WaitCrawTime) * time.Millisecond

--- a/be-classlist/biz/usecase/classer_helpers.go
+++ b/be-classlist/biz/usecase/classer_helpers.go
@@ -40,6 +40,20 @@ type refreshRetryMessage struct {
 	MaxAttempts int    `json:"max_attempts"`
 }
 
+// retryHandoffError 表示刷新失败后，下一条延迟重试消息未能发布。
+// 只有该错误需要保留当前 Kafka 消息并让 consumer group 重新消费。
+type retryHandoffError struct {
+	cause error
+}
+
+func (e *retryHandoffError) Error() string {
+	return fmt.Sprintf("refresh retry handoff failed: %v", e.cause)
+}
+
+func (e *retryHandoffError) Unwrap() error {
+	return e.cause
+}
+
 // 统一本地查询逻辑 GetClassesFromLocal + GetLastRefreshTime
 func (cluc *ClassUsecase) loadLocal(ctx context.Context, stuID, year, semester string) (classes []*model.ClassInfoBO, lastRefresh *time.Time, err error) {
 	logh := cluc.log.WithContext(ctx)
@@ -246,13 +260,15 @@ func (cluc *ClassUsecase) doCrawlAttemptWithSingleflight(ctx context.Context, st
 	if jobTimeout <= 0 {
 		jobTimeout = defaultRefreshJobTimeout
 	}
-	key := classRefreshSingleflightKey(stuID, year, semester)
+	key := classRefreshSingleflightKey(stuID, year, semester, attempt, maxAttempts)
 	resultCh := cluc.sfGroup.DoChan(key, func() (interface{}, error) {
 		jobCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), jobTimeout)
 		defer cancel()
 		res, err := cluc.crawlOnce(jobCtx, stuID, year, semester)
 		if err != nil {
-			cluc.coordinateRefreshRetry(jobCtx, stuID, year, semester, attempt, maxAttempts, err)
+			if handoffErr := cluc.coordinateRefreshRetry(jobCtx, stuID, year, semester, attempt, maxAttempts, err); handoffErr != nil {
+				return nil, errors.Join(err, &retryHandoffError{cause: handoffErr})
+			}
 			return nil, err
 		}
 		if res == nil {
@@ -488,7 +504,7 @@ func (cluc *ClassUsecase) sendRetryMsg(ctx context.Context, stuID, year, semeste
 	return err
 }
 
-func (cluc *ClassUsecase) coordinateRefreshRetry(ctx context.Context, stuID, year, semester string, attempt, maxAttempts int, cause error) {
+func (cluc *ClassUsecase) coordinateRefreshRetry(ctx context.Context, stuID, year, semester string, attempt, maxAttempts int, cause error) error {
 	logh := cluc.log.WithContext(ctx)
 	if !shouldRetryClassRefresh(cause) {
 		logh.Warn("class refresh failure is not retryable",
@@ -498,7 +514,7 @@ func (cluc *ClassUsecase) coordinateRefreshRetry(ctx context.Context, stuID, yea
 			logger.Int("attempt", attempt),
 			logger.Error(cause),
 		)
-		return
+		return nil
 	}
 	if attempt >= maxAttempts {
 		// 超过最大重试，打日志
@@ -510,7 +526,7 @@ func (cluc *ClassUsecase) coordinateRefreshRetry(ctx context.Context, stuID, yea
 			logger.Int("max_attempts", maxAttempts),
 			logger.Error(cause),
 		)
-		return
+		return nil
 	}
 
 	nextAttempt := attempt + 1
@@ -526,7 +542,9 @@ func (cluc *ClassUsecase) coordinateRefreshRetry(ctx context.Context, stuID, yea
 			logger.Int("max_attempts", maxAttempts),
 			logger.Error(err),
 		)
+		return fmt.Errorf("publish refresh retry attempt %d: %w", nextAttempt, err)
 	}
+	return nil
 }
 
 // 错误白名单，确定是否需要重试
@@ -648,13 +666,18 @@ func (cluc *ClassUsecase) handleRetryMessage(ctx context.Context, _ []byte, valu
 		configuredTimeout := time.Duration(cluc.conf.ClassListConf.WaitCrawTime) * time.Millisecond
 		retryJobTimeout = max(retryJobTimeout, configuredTimeout)
 	}
-	_, err := cluc.doCrawlAttemptWithSingleflight(ctx, retryInfo.StuID, retryInfo.Year, retryInfo.Semester, retryInfo.Attempt, retryInfo.MaxAttempts, retryJobTimeout)
+	_, err = cluc.doCrawlAttemptWithSingleflight(ctx, retryInfo.StuID, retryInfo.Year, retryInfo.Semester, retryInfo.Attempt, retryInfo.MaxAttempts, retryJobTimeout)
 	if err != nil {
 		logh.Errorf("handle refresh retry msg failed stu_id=%s year=%s semester=%s attempt=%d max_attempts=%d: %+v", retryInfo.StuID, retryInfo.Year, retryInfo.Semester, retryInfo.Attempt, retryInfo.MaxAttempts, err)
-		return err
+		var handoffErr *retryHandoffError
+		if errors.As(err, &handoffErr) {
+			return false, err
+		}
+		// 下一条重试已发布，或当前错误已判定为终态，可以确认当前消息。
+		return true, err
 	}
 	logh.Infof("handle refresh retry msg succeeded stu_id=%s year=%s semester=%s attempt=%d", retryInfo.StuID, retryInfo.Year, retryInfo.Semester, retryInfo.Attempt)
-	return nil
+	return true, nil
 }
 
 func extractJxb(infos []*model.ClassInfoBO) []string {

--- a/be-classlist/biz/usecase/classer_helpers.go
+++ b/be-classlist/biz/usecase/classer_helpers.go
@@ -15,12 +15,21 @@ import (
 	"github.com/asynccnu/ccnubox-be/common/tool"
 )
 
-const refreshRetryConsumerGroup = "be-classlist-refresh-retry-worker"
+const (
+	refreshRetryConsumerGroup  = "be-classlist-refresh-retry-worker"
+	refreshRetryMessageVersion = 1
+	maxRefreshRetryAttempts    = 3
+	defaultRefreshJobTimeout   = 15 * time.Second
+	retryPublishTimeout        = 5 * time.Second
+)
 
 type refreshRetryMessage struct {
-	StuID    string `json:"stu_id"`
-	Year     string `json:"year"`
-	Semester string `json:"semester"`
+	Version     int    `json:"version"`
+	StuID       string `json:"stu_id"`
+	Year        string `json:"year"`
+	Semester    string `json:"semester"`
+	Attempt     int    `json:"attempt"`
+	MaxAttempts int    `json:"max_attempts"`
 }
 
 // 统一本地查询逻辑 GetClassesFromLocal + GetLastRefreshTime
@@ -382,14 +391,20 @@ func (cluc *ClassUsecase) getCourseFromCrawler(ctx context.Context, stuID string
 	return ci, sc, sum, nil
 }
 
-// 发送重试消息
-func (cluc *ClassUsecase) sendRetryMsg(ctx context.Context, stuID, year, semester string) error {
+// 发送一次有界重试消息。attempt 表示即将执行的异步重试序号，从 1 开始。
+func (cluc *ClassUsecase) sendRetryMsg(ctx context.Context, stuID, year, semester string, attempt, maxAttempts int) error {
 	logh := cluc.log.WithContext(ctx)
+	if cluc.delayQue == nil {
+		return errors.New("refresh retry queue is unavailable")
+	}
 
 	retryInfo := refreshRetryMessage{
-		StuID:    stuID,
-		Year:     year,
-		Semester: semester,
+		Version:     refreshRetryMessageVersion,
+		StuID:       stuID,
+		Year:        year,
+		Semester:    semester,
+		Attempt:     attempt,
+		MaxAttempts: maxAttempts,
 	}
 	key := fmt.Sprintf("be-classlist-refresh-retry-%d", time.Now().UnixMilli())
 	val, err := json.Marshal(&retryInfo)

--- a/be-classlist/biz/usecase/classer_helpers.go
+++ b/be-classlist/biz/usecase/classer_helpers.go
@@ -587,28 +587,55 @@ func (cluc *ClassUsecase) startRetryConsumer() {
 	}()
 }
 
-func (cluc *ClassUsecase) handleRetryMessage(ctx context.Context, _ []byte, value []byte) error {
-	logh := cluc.log.WithContext(ctx)
-
+func decodeRefreshRetryMessage(value []byte) (refreshRetryMessage, error) {
 	var retryInfo refreshRetryMessage
 	if err := json.Unmarshal(value, &retryInfo); err != nil {
 		logh.Errorf("unmarshal refresh retry msg failed: value=%s, err=%+v", string(value), err)
 		return fmt.Errorf("unmarshal refresh retry message: %w", err)
 	}
 	if retryInfo.StuID == "" || retryInfo.Year == "" || retryInfo.Semester == "" {
-		logh.Errorf("invalid refresh retry msg: value=%s", string(value))
-		return fmt.Errorf("invalid refresh retry message: missing required field")
+		return refreshRetryMessage{}, errors.New("invalid refresh retry message: missing required field")
 	}
-	if retryInfo.Version != refreshRetryMessageVersion {
-		logh.Errorf("unsupported refresh retry msg version: value=%s", string(value))
-		return fmt.Errorf("unsupported refresh retry message version: %d", retryInfo.Version)
-	}
-	if retryInfo.MaxAttempts <= 0 || retryInfo.MaxAttempts > maxRefreshRetryAttempts {
+
+	// 兼容旧消息
+	switch retryInfo.Version {
+	case 0:
+		if retryInfo.Attempt != 0 || retryInfo.MaxAttempts != 0 {
+			return refreshRetryMessage{}, fmt.Errorf(
+				"invalid legacy refresh retry message: attempt=%d max_attempts=%d",
+				retryInfo.Attempt,
+				retryInfo.MaxAttempts,
+			)
+		}
+		retryInfo.Version = refreshRetryMessageVersion
+		retryInfo.Attempt = 1
 		retryInfo.MaxAttempts = maxRefreshRetryAttempts
+	case refreshRetryMessageVersion:
+		if retryInfo.MaxAttempts <= 0 || retryInfo.MaxAttempts > maxRefreshRetryAttempts {
+			retryInfo.MaxAttempts = maxRefreshRetryAttempts
+		}
+	default:
+		return refreshRetryMessage{}, fmt.Errorf("unsupported refresh retry message version: %d", retryInfo.Version)
 	}
+
 	if retryInfo.Attempt < 1 || retryInfo.Attempt > retryInfo.MaxAttempts {
-		logh.Errorf("invalid refresh retry attempt: attempt=%d max_attempts=%d value=%s", retryInfo.Attempt, retryInfo.MaxAttempts, string(value))
-		return fmt.Errorf("invalid refresh retry attempt: attempt=%d max_attempts=%d", retryInfo.Attempt, retryInfo.MaxAttempts)
+		return refreshRetryMessage{}, fmt.Errorf(
+			"invalid refresh retry attempt: attempt=%d max_attempts=%d",
+			retryInfo.Attempt,
+			retryInfo.MaxAttempts,
+		)
+	}
+	return retryInfo, nil
+}
+
+func (cluc *ClassUsecase) handleRetryMessage(ctx context.Context, _ []byte, value []byte) (bool, error) {
+	logh := cluc.log.WithContext(ctx)
+
+	retryInfo, err := decodeRefreshRetryMessage(value)
+	if err != nil {
+		logh.Errorf("invalid refresh retry msg: value=%s, err=%+v", string(value), err)
+		// 没有 DLQ 时确认非法消息，避免 poison message 永久阻塞分区。
+		return true, err
 	}
 
 	logh.Infof("consume refresh retry msg stu_id=%s year=%s semester=%s attempt=%d max_attempts=%d", retryInfo.StuID, retryInfo.Year, retryInfo.Semester, retryInfo.Attempt, retryInfo.MaxAttempts)

--- a/be-classlist/biz/usecase/classer_helpers.go
+++ b/be-classlist/biz/usecase/classer_helpers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"syscall"
 	"time"
 
 	"github.com/asynccnu/ccnubox-be/be-classlist/biz"
@@ -534,8 +535,7 @@ func shouldRetryClassRefresh(err error) bool {
 		return false
 	}
 
-	if errors.Is(err, biz.ErrCrawlerAuthentication) ||
-		errors.Is(err, biz.ErrCrawlerProtocol) ||
+	if errors.Is(err, biz.ErrCrawlerProtocol) ||
 		errors.Is(err, biz.ErrCrawlerEmptyResult) ||
 		errors.Is(err, biz.ErrCookieUnavailable) ||
 		errors.Is(err, biz.ErrUnsupportedStudentType) ||
@@ -546,21 +546,22 @@ func shouldRetryClassRefresh(err error) bool {
 
 	if errors.Is(err, biz.ErrRefreshPersistence) {
 		var mysqlErr *mysql.MySQLError
-		if !errors.As(err, &mysqlErr) {
-			return false
-		}
-		switch mysqlErr.Number {
-		case 1205, 1213, 2006, 2013:
-			return true
-		default:
-			return false
+		if errors.As(err, &mysqlErr) {
+			switch mysqlErr.Number {
+			case 1205, 1213, 2006, 2013:
+				return true
+			}
 		}
 	}
 
 	if errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, biz.ErrCrawlerAuthentication) ||
 		errors.Is(err, biz.ErrCrawlerTemporary) ||
 		errors.Is(err, io.EOF) ||
-		errors.Is(err, io.ErrUnexpectedEOF) {
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.EPIPE) {
 		return true
 	}
 
@@ -572,7 +573,11 @@ func shouldRetryClassRefresh(err error) bool {
 	}
 
 	var netErr net.Error
-	return errors.As(err, &netErr) && (netErr.Timeout() || netErr.Temporary())
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	var opErr *net.OpError
+	return errors.As(err, &opErr)
 }
 
 func (cluc *ClassUsecase) startRetryConsumer() {

--- a/be-classlist/biz/usecase/classer_helpers.go
+++ b/be-classlist/biz/usecase/classer_helpers.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	refreshRetryConsumerGroup  = "be-classlist-refresh-retry-worker-v1"
+	refreshRetryConsumerGroup  = "be-classlist-refresh-retry-worker"
 	refreshRetryMessageVersion = 1
 	maxRefreshRetryAttempts    = 3
 	defaultRefreshJobTimeout   = 15 * time.Second

--- a/be-classlist/biz/usecase/classer_helpers.go
+++ b/be-classlist/biz/usecase/classer_helpers.go
@@ -536,7 +536,7 @@ func (cluc *ClassUsecase) startRetryConsumer() {
 	}()
 }
 
-func (cluc *ClassUsecase) handleRetryMessage(ctx context.Context, _ []byte, value []byte) {
+func (cluc *ClassUsecase) handleRetryMessage(ctx context.Context, _ []byte, value []byte) error {
 	logh := cluc.log.WithContext(ctx)
 
 	var retryInfo refreshRetryMessage
@@ -546,22 +546,18 @@ func (cluc *ClassUsecase) handleRetryMessage(ctx context.Context, _ []byte, valu
 	}
 	if retryInfo.StuID == "" || retryInfo.Year == "" || retryInfo.Semester == "" {
 		logh.Errorf("invalid refresh retry msg: value=%s", string(value))
-		return
+		return fmt.Errorf("invalid refresh retry message: missing required field")
 	}
-	if retryInfo.Version != 0 && retryInfo.Version != refreshRetryMessageVersion {
+	if retryInfo.Version != refreshRetryMessageVersion {
 		logh.Errorf("unsupported refresh retry msg version: value=%s", string(value))
-		return
-	}
-	// 兼容升级前已经在 Kafka 中、尚未消费的无 attempt 消息。
-	if retryInfo.Attempt == 0 {
-		retryInfo.Attempt = 1
+		return fmt.Errorf("unsupported refresh retry message version: %d", retryInfo.Version)
 	}
 	if retryInfo.MaxAttempts <= 0 || retryInfo.MaxAttempts > maxRefreshRetryAttempts {
 		retryInfo.MaxAttempts = maxRefreshRetryAttempts
 	}
 	if retryInfo.Attempt < 1 || retryInfo.Attempt > retryInfo.MaxAttempts {
 		logh.Errorf("invalid refresh retry attempt: attempt=%d max_attempts=%d value=%s", retryInfo.Attempt, retryInfo.MaxAttempts, string(value))
-		return
+		return fmt.Errorf("invalid refresh retry attempt: attempt=%d max_attempts=%d", retryInfo.Attempt, retryInfo.MaxAttempts)
 	}
 
 	logh.Infof("consume refresh retry msg stu_id=%s year=%s semester=%s attempt=%d max_attempts=%d", retryInfo.StuID, retryInfo.Year, retryInfo.Semester, retryInfo.Attempt, retryInfo.MaxAttempts)
@@ -571,12 +567,13 @@ func (cluc *ClassUsecase) handleRetryMessage(ctx context.Context, _ []byte, valu
 		configuredTimeout := time.Duration(cluc.conf.ClassListConf.WaitCrawTime) * time.Millisecond
 		retryJobTimeout = max(retryJobTimeout, configuredTimeout)
 	}
-	_, err := cluc.doCrawlAttemptWithSingleflight(ctx, retryKey, retryInfo.StuID, retryInfo.Year, retryInfo.Semester, retryInfo.Attempt, retryInfo.MaxAttempts, retryJobTimeout)
+	_, err := cluc.doCrawlAttemptWithSingleflight(ctx, retryInfo.StuID, retryInfo.Year, retryInfo.Semester, retryInfo.Attempt, retryInfo.MaxAttempts, retryJobTimeout)
 	if err != nil {
 		logh.Errorf("handle refresh retry msg failed stu_id=%s year=%s semester=%s attempt=%d max_attempts=%d: %+v", retryInfo.StuID, retryInfo.Year, retryInfo.Semester, retryInfo.Attempt, retryInfo.MaxAttempts, err)
-		return
+		return err
 	}
 	logh.Infof("handle refresh retry msg succeeded stu_id=%s year=%s semester=%s attempt=%d", retryInfo.StuID, retryInfo.Year, retryInfo.Semester, retryInfo.Attempt)
+	return nil
 }
 
 func extractJxb(infos []*model.ClassInfoBO) []string {

--- a/be-classlist/client/ccnu.go
+++ b/be-classlist/client/ccnu.go
@@ -23,7 +23,7 @@ func (c *CCNUService) GetCookie(ctx context.Context, stuID string) (string, erro
 	if err != nil {
 		return "", fmt.Errorf("get cookie from user service: %w", err)
 	}
-	if resp == nil {
+	if resp == nil || resp.Cookie == "" {
 		return "", fmt.Errorf("get cookie from user service: %w", biz.ErrCookieUnavailable)
 	}
 	return resp.Cookie, nil

--- a/be-classlist/client/ccnu.go
+++ b/be-classlist/client/ccnu.go
@@ -20,8 +20,11 @@ func (c *CCNUService) GetCookie(ctx context.Context, stuID string) (string, erro
 	resp, err := c.user.GetCookie(ctx, &userv1.GetCookieRequest{
 		StudentId: stuID,
 	})
-	if err != nil || resp == nil {
-		return "", fmt.Errorf("No cookie was fetched from user service err=%v", err)
+	if err != nil {
+		return "", fmt.Errorf("get cookie from user service: %w", err)
+	}
+	if resp == nil {
+		return "", fmt.Errorf("get cookie from user service: %w", biz.ErrCookieUnavailable)
 	}
 	return resp.Cookie, nil
 }

--- a/be-classlist/crawler/crawler_1.go
+++ b/be-classlist/crawler/crawler_1.go
@@ -34,7 +34,8 @@ type Crawler struct {
 func NewClassCrawler(pg ProxyGetter, l logger.Logger) *Crawler {
 	newClient := func() interface{} {
 		return &http.Client{
-			Timeout: 40 * time.Second,
+			Timeout:       40 * time.Second,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
 			Transport: &http.Transport{
 				MaxIdleConns:        10, // 既然使用sync.Pool管理对象，这个不宜过大
 				IdleConnTimeout:     90 * time.Second,
@@ -108,7 +109,8 @@ func (c *Crawler) GetClassInfoForGraduateStudent(ctx context.Context, stuID, yea
 	resp, err := client.Do(req)
 	if err != nil {
 		logh.Errorf("client.Do err=%v", err)
-		return nil, nil, -1, errorx.Errorf("crawler.crawler1.GetClassInfoForGraduateStudent request failed: %w", err)
+		requestErr := errorx.Errorf("crawler.crawler1.GetClassInfoForGraduateStudent request failed: %w", err)
+		return nil, nil, -1, classifyResponseError(nil, requestErr)
 	}
 	defer resp.Body.Close()
 
@@ -116,12 +118,13 @@ func (c *Crawler) GetClassInfoForGraduateStudent(ctx context.Context, stuID, yea
 	bodyBytes, err := httpx.ReadResponse(resp)
 	if err != nil {
 		logh.Errorf("failed to read response body: %v", err)
-		return nil, nil, -1, err
+		return nil, nil, -1, classifyResponseError(resp, err)
 	}
 	infos, Scs, sum, err := extractUndergraduateData(bodyBytes, stuID, xnm, xqm)
 	if err != nil {
 		logh.Errorf("extractUndergraduateData err=%v", err)
-		return nil, nil, -1, errorx.Errorf("crawler.crawler1.GetClassInfoForGraduateStudent extract failed: %w", err)
+		extractErr := errorx.Errorf("crawler.crawler1.GetClassInfoForGraduateStudent extract failed: %w", err)
+		return nil, nil, -1, classifyPayloadError(bodyBytes, extractErr)
 	}
 	return infos, Scs, sum, nil
 }
@@ -173,7 +176,8 @@ func (c *Crawler) GetClassInfosForUndergraduate(ctx context.Context, stuID, year
 	resp, err := client.Do(req)
 	if err != nil {
 		logh.Errorf("client.Do err=%v", err)
-		return nil, nil, -1, errorx.Errorf("crawler.crawler1.GetClassInfosForUndergraduate request failed: %w", err)
+		requestErr := errorx.Errorf("crawler.crawler1.GetClassInfosForUndergraduate request failed: %w", err)
+		return nil, nil, -1, classifyResponseError(nil, requestErr)
 	}
 	defer resp.Body.Close()
 
@@ -181,12 +185,13 @@ func (c *Crawler) GetClassInfosForUndergraduate(ctx context.Context, stuID, year
 	bodyBytes, err := httpx.ReadResponse(resp)
 	if err != nil {
 		logh.Errorf("failed to read response body: %v", err)
-		return nil, nil, -1, err
+		return nil, nil, -1, classifyResponseError(resp, err)
 	}
 	infos, Scs, sum, err := extractUndergraduateData(bodyBytes, stuID, xnm, xqm)
 	if err != nil {
 		logh.Errorf("extractUndergraduateData err=%v", err)
-		return nil, nil, -1, errorx.Errorf("crawler.crawler1.GetClassInfosForUndergraduate extract failed: %w", err)
+		extractErr := errorx.Errorf("crawler.crawler1.GetClassInfosForUndergraduate extract failed: %w", err)
+		return nil, nil, -1, classifyPayloadError(bodyBytes, extractErr)
 	}
 
 	return infos, Scs, sum, nil

--- a/be-classlist/crawler/crawler_2.go
+++ b/be-classlist/crawler/crawler_2.go
@@ -39,7 +39,8 @@ type Crawler2 struct {
 func NewClassCrawler2(pg ProxyGetter, l logger.Logger) *Crawler2 {
 	newClient := func() interface{} {
 		return &http.Client{
-			Timeout: 40 * time.Second,
+			Timeout:       40 * time.Second,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
 			Transport: &http.Transport{
 				MaxIdleConns:        10, // 既然使用sync.Pool管理对象，这个不宜过大
 				IdleConnTimeout:     90 * time.Second,
@@ -118,7 +119,7 @@ func (c *Crawler2) GetClassInfosForUndergraduate(ctx context.Context, stuID, yea
 	body, err := httpx.ReadResponse(resp)
 	if err != nil {
 		logh.Errorf("read body failed:%v", err)
-		return nil, nil, -1, err
+		return nil, nil, -1, classifyResponseError(resp, err)
 	}
 
 	infos, err := c.extractCourses(ctx, year, semester, body)
@@ -186,7 +187,7 @@ func (c *Crawler2) GetClassInfoForGraduateStudent(ctx context.Context, stuID, ye
 	bodyBytes, err := httpx.ReadResponse(resp)
 	if err != nil {
 		logh.Errorf("failed to read response body: %v", err)
-		return nil, nil, -1, err
+		return nil, nil, -1, classifyResponseError(resp, err)
 	}
 	infos, Scs, sum, err := extractGraduateData(bodyBytes, stuID, xnm, xqm)
 	if err != nil {

--- a/be-classlist/crawler/crawler_2.go
+++ b/be-classlist/crawler/crawler_2.go
@@ -124,7 +124,7 @@ func (c *Crawler2) GetClassInfosForUndergraduate(ctx context.Context, stuID, yea
 	infos, err := c.extractCourses(ctx, year, semester, body)
 	if err != nil {
 		logh.Errorf("failed to extract infos: %v", err)
-		return nil, nil, -1, fmt.Errorf("failed to extract infos: %v", err)
+		return nil, nil, -1, fmt.Errorf("failed to extract infos: %w", err)
 	}
 
 	scs := make([]*model.StudentCourseBO, 0, len(infos))
@@ -208,7 +208,7 @@ func (c *Crawler2) extractCourses(ctx context.Context, year, semester string, ht
 	logh := c.log.WithContext(ctx)
 	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(html))
 	if err != nil {
-		return nil, fmt.Errorf("NewDocumentFromReader err: %v", err)
+		return nil, fmt.Errorf("NewDocumentFromReader err: %w", err)
 	}
 
 	var classInfos []*model.ClassInfoBO

--- a/be-classlist/crawler/crawler_2.go
+++ b/be-classlist/crawler/crawler_2.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
+	"github.com/asynccnu/ccnubox-be/be-classlist/biz"
 	"github.com/asynccnu/ccnubox-be/be-classlist/biz/model"
 	"github.com/asynccnu/ccnubox-be/be-classlist/pkg/tool"
 	"github.com/asynccnu/ccnubox-be/common/pkg/errorx"
@@ -112,7 +113,7 @@ func (c *Crawler2) GetClassInfosForUndergraduate(ctx context.Context, stuID, yea
 	resp, err := client.Do(req)
 	if err != nil {
 		logh.Errorf("client.Do err=%v", err)
-		return nil, nil, -1, err
+		return nil, nil, -1, classifyResponseError(nil, fmt.Errorf("crawler2 undergraduate request failed: %w", err))
 	}
 	defer resp.Body.Close()
 
@@ -125,7 +126,7 @@ func (c *Crawler2) GetClassInfosForUndergraduate(ctx context.Context, stuID, yea
 	infos, err := c.extractCourses(ctx, year, semester, body)
 	if err != nil {
 		logh.Errorf("failed to extract infos: %v", err)
-		return nil, nil, -1, fmt.Errorf("failed to extract infos: %w", err)
+		return nil, nil, -1, classifyPayloadError(body, fmt.Errorf("crawler2 undergraduate extract failed: %w", err))
 	}
 
 	scs := make([]*model.StudentCourseBO, 0, len(infos))
@@ -179,7 +180,8 @@ func (c *Crawler2) GetClassInfoForGraduateStudent(ctx context.Context, stuID, ye
 	resp, err := client.Do(req)
 	if err != nil {
 		logh.Errorf("client.Do err=%v", err)
-		return nil, nil, -1, errorx.Errorf("crawler.crawler2.GetClassInfoForGraduateStudent request failed: %w", err)
+		requestErr := errorx.Errorf("crawler.crawler2.GetClassInfoForGraduateStudent request failed: %w", err)
+		return nil, nil, -1, classifyResponseError(nil, requestErr)
 	}
 	defer resp.Body.Close()
 
@@ -192,7 +194,8 @@ func (c *Crawler2) GetClassInfoForGraduateStudent(ctx context.Context, stuID, ye
 	infos, Scs, sum, err := extractGraduateData(bodyBytes, stuID, xnm, xqm)
 	if err != nil {
 		logh.Errorf("extractUndergraduateData err=%v", err)
-		return nil, nil, -1, errorx.Errorf("crawler.crawler2.GetClassInfoForGraduateStudent extract failed: %w", err)
+		extractErr := errorx.Errorf("crawler.crawler2.GetClassInfoForGraduateStudent extract failed: %w", err)
+		return nil, nil, -1, classifyPayloadError(bodyBytes, extractErr)
 	}
 	return infos, Scs, sum, nil
 }
@@ -207,6 +210,9 @@ func (c *Crawler2) getys(year, semester string) string {
 
 func (c *Crawler2) extractCourses(ctx context.Context, year, semester string, html []byte) ([]*model.ClassInfoBO, error) {
 	logh := c.log.WithContext(ctx)
+	if looksLikeAuthenticationPage(html) {
+		return nil, fmt.Errorf("%w: undergraduate endpoint returned a login page", biz.ErrCrawlerAuthentication)
+	}
 	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(html))
 	if err != nil {
 		return nil, fmt.Errorf("NewDocumentFromReader err: %w", err)
@@ -262,6 +268,11 @@ func (c *Crawler2) extractCourses(ctx context.Context, year, semester string, ht
 
 		classInfos = append(classInfos, &classInfo)
 	})
+	if len(classInfos) == 0 {
+		// 该旧版 HTML 爬虫无法可靠区分“空课表”和结构变化后的错误页。宁可保留本地
+		// 快照并报告不可重试错误，也不能把错误页当成空课表写回数据库。
+		return nil, fmt.Errorf("%w: no course elements found in undergraduate response", biz.ErrCrawlerEmptyResult)
+	}
 	return classInfos, nil
 }
 

--- a/be-classlist/crawler/crawler_3.go
+++ b/be-classlist/crawler/crawler_3.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/asynccnu/ccnubox-be/be-classlist/biz"
 	"github.com/asynccnu/ccnubox-be/be-classlist/biz/model"
 	"github.com/asynccnu/ccnubox-be/be-classlist/pkg/tool"
 	"github.com/asynccnu/ccnubox-be/common/bizpkg/proxy"
@@ -99,13 +100,13 @@ func (c *Crawler3) GetClassInfosForUndergraduate(ctx context.Context, stuID, yea
 	body, err := httpx.ReadResponse(resp)
 	if err != nil {
 		logh.Errorf("read body failed:%v", err)
-		return nil, nil, -1, err
+		return nil, nil, -1, classifyResponseError(resp, err)
 	}
 
 	infos, err := c.extractCourses(ctx, year, semester, body)
 	if err != nil {
 		logh.Errorf("failed to extract infos: %v", err)
-		return nil, nil, -1, fmt.Errorf("failed to extract infos: %v", err)
+		return nil, nil, -1, fmt.Errorf("%w: failed to extract infos: %w", biz.ErrCrawlerProtocol, err)
 	}
 
 	scs := make([]*model.StudentCourseBO, 0, len(infos))
@@ -355,12 +356,12 @@ func (c *Crawler3) GetClassInfoForGraduateStudent(ctx context.Context, stuID, ye
 	bodyBytes, err := httpx.ReadResponse(resp)
 	if err != nil {
 		logh.Errorf("failed to read response body: %v", err)
-		return nil, nil, -1, err
+		return nil, nil, -1, classifyResponseError(resp, err)
 	}
 	infos, Scs, sum, err := extractGraduateData(bodyBytes, stuID, xnm, xqm)
 	if err != nil {
 		logh.Errorf("extractUndergraduateData err=%v", err)
-		return nil, nil, -1, errorx.Errorf("crawler.crawler3.GetClassInfoForGraduateStudent extract failed: %w", err)
+		return nil, nil, -1, fmt.Errorf("%w: crawler.crawler3.GetClassInfoForGraduateStudent extract failed: %w", biz.ErrCrawlerProtocol, err)
 	}
 	return infos, Scs, sum, nil
 }

--- a/be-classlist/crawler/crawler_3.go
+++ b/be-classlist/crawler/crawler_3.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/asynccnu/ccnubox-be/be-classlist/biz"
 	"github.com/asynccnu/ccnubox-be/be-classlist/biz/model"
 	"github.com/asynccnu/ccnubox-be/be-classlist/pkg/tool"
 	"github.com/asynccnu/ccnubox-be/common/bizpkg/proxy"
@@ -93,7 +92,7 @@ func (c *Crawler3) GetClassInfosForUndergraduate(ctx context.Context, stuID, yea
 	resp, err := client.Client.Do(req)
 	if err != nil {
 		logh.Errorf("client.Do err=%v", err)
-		return nil, nil, -1, err
+		return nil, nil, -1, classifyResponseError(nil, fmt.Errorf("crawler3 undergraduate request failed: %w", err))
 	}
 	defer resp.Body.Close()
 
@@ -106,7 +105,7 @@ func (c *Crawler3) GetClassInfosForUndergraduate(ctx context.Context, stuID, yea
 	infos, err := c.extractCourses(ctx, year, semester, body)
 	if err != nil {
 		logh.Errorf("failed to extract infos: %v", err)
-		return nil, nil, -1, fmt.Errorf("%w: failed to extract infos: %w", biz.ErrCrawlerProtocol, err)
+		return nil, nil, -1, classifyPayloadError(body, fmt.Errorf("crawler3 undergraduate extract failed: %w", err))
 	}
 
 	scs := make([]*model.StudentCourseBO, 0, len(infos))
@@ -348,7 +347,8 @@ func (c *Crawler3) GetClassInfoForGraduateStudent(ctx context.Context, stuID, ye
 	resp, err := client.Client.Do(req)
 	if err != nil {
 		logh.Errorf("client.Do err=%v", err)
-		return nil, nil, -1, errorx.Errorf("crawler.crawler3.GetClassInfoForGraduateStudent request failed: %w", err)
+		requestErr := errorx.Errorf("crawler.crawler3.GetClassInfoForGraduateStudent request failed: %w", err)
+		return nil, nil, -1, classifyResponseError(nil, requestErr)
 	}
 	defer resp.Body.Close()
 
@@ -361,7 +361,7 @@ func (c *Crawler3) GetClassInfoForGraduateStudent(ctx context.Context, stuID, ye
 	infos, Scs, sum, err := extractGraduateData(bodyBytes, stuID, xnm, xqm)
 	if err != nil {
 		logh.Errorf("extractUndergraduateData err=%v", err)
-		return nil, nil, -1, fmt.Errorf("%w: crawler.crawler3.GetClassInfoForGraduateStudent extract failed: %w", biz.ErrCrawlerProtocol, err)
+		return nil, nil, -1, classifyPayloadError(bodyBytes, fmt.Errorf("crawler3 graduate extract failed: %w", err))
 	}
 	return infos, Scs, sum, nil
 }

--- a/be-classlist/crawler/errors.go
+++ b/be-classlist/crawler/errors.go
@@ -1,13 +1,18 @@
 package crawler
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/asynccnu/ccnubox-be/be-classlist/biz"
 	"github.com/asynccnu/ccnubox-be/common/pkg/httpx"
 )
+
+const maxAuthenticationPageInspectionBytes = 64 << 10
 
 // 分类HTTP响应的错误
 // 复用了httpx包的哨兵错误
@@ -15,22 +20,24 @@ func classifyResponseError(resp *http.Response, err error) error {
 	if err == nil {
 		return nil
 	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
 
 	if errors.Is(err, httpx.ErrUnexpectedStatus) && resp != nil {
 		statusCode := resp.StatusCode
 		switch {
-		case statusCode == http.StatusMovedPermanently,
-			statusCode == http.StatusFound,
-			statusCode == http.StatusSeeOther,
-			statusCode == http.StatusTemporaryRedirect,
-			statusCode == http.StatusPermanentRedirect,
-			statusCode == http.StatusUnauthorized,
+		case statusCode == http.StatusUnauthorized,
 			statusCode == http.StatusForbidden:
 			return fmt.Errorf("%w: status=%d: %w", biz.ErrCrawlerAuthentication, statusCode, err)
-		case statusCode == http.StatusRequestTimeout,
+		case isHTTPRedirect(statusCode) && isAuthenticationRedirect(resp):
+			return fmt.Errorf("%w: status=%d: %w", biz.ErrCrawlerAuthentication, statusCode, err)
+		case statusCode == http.StatusProxyAuthRequired,
+			statusCode == http.StatusRequestTimeout,
+			statusCode == http.StatusMisdirectedRequest,
 			statusCode == http.StatusTooEarly,
 			statusCode == http.StatusTooManyRequests,
-			statusCode >= http.StatusInternalServerError:
+			statusCode >= http.StatusInternalServerError && statusCode <= 599:
 			return fmt.Errorf("%w: status=%d: %w", biz.ErrCrawlerTemporary, statusCode, err)
 		default:
 			return fmt.Errorf("%w: status=%d: %w", biz.ErrCrawlerProtocol, statusCode, err)
@@ -43,6 +50,72 @@ func classifyResponseError(resp *http.Response, err error) error {
 		return fmt.Errorf("%w: %w", biz.ErrCrawlerProtocol, err)
 	}
 
-	// Body 读取时的 EOF、连接重置等错误保留原类型，由 usecase 的 net.Error/io 错误分类处理。
-	return err
+	return fmt.Errorf("%w: %w", biz.ErrCrawlerTemporary, err)
+}
+
+func classifyPayloadError(body []byte, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, biz.ErrCrawlerAuthentication) ||
+		errors.Is(err, biz.ErrCrawlerProtocol) ||
+		errors.Is(err, biz.ErrCrawlerEmptyResult) {
+		return err
+	}
+	if looksLikeAuthenticationPage(body) {
+		return fmt.Errorf("%w: upstream returned an authentication page: %w", biz.ErrCrawlerAuthentication, err)
+	}
+	return fmt.Errorf("%w: %w", biz.ErrCrawlerProtocol, err)
+}
+
+func isHTTPRedirect(statusCode int) bool {
+	return statusCode >= http.StatusMultipleChoices && statusCode < http.StatusBadRequest
+}
+
+func isAuthenticationRedirect(resp *http.Response) bool {
+	if resp == nil || !isHTTPRedirect(resp.StatusCode) {
+		return false
+	}
+
+	location := strings.ToLower(strings.TrimSpace(resp.Header.Get("Location")))
+	if location == "" {
+		return resp.StatusCode == http.StatusFound || resp.StatusCode == http.StatusSeeOther
+	}
+	for _, marker := range []string{"login", "authserver", "passport", "/cas", "sso"} {
+		if strings.Contains(location, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeAuthenticationPage(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	if len(body) > maxAuthenticationPageInspectionBytes {
+		body = body[:maxAuthenticationPageInspectionBytes]
+	}
+	sample := bytes.ToLower(body)
+	if !bytes.Contains(sample, []byte("<html")) &&
+		!bytes.Contains(sample, []byte("<!doctype html")) &&
+		!bytes.Contains(sample, []byte("<form")) {
+		return false
+	}
+
+	markers := [][]byte{
+		[]byte("login"),
+		[]byte("/cas"),
+		[]byte("sso"),
+		[]byte("name=\"password\""),
+		[]byte("name='password'"),
+		[]byte("统一身份认证"),
+		[]byte("登录"),
+	}
+	for _, marker := range markers {
+		if bytes.Contains(sample, marker) {
+			return true
+		}
+	}
+	return false
 }

--- a/be-classlist/crawler/errors.go
+++ b/be-classlist/crawler/errors.go
@@ -19,7 +19,11 @@ func classifyResponseError(resp *http.Response, err error) error {
 	if errors.Is(err, httpx.ErrUnexpectedStatus) && resp != nil {
 		statusCode := resp.StatusCode
 		switch {
-		case statusCode >= http.StatusMultipleChoices && statusCode < http.StatusBadRequest,
+		case statusCode == http.StatusMovedPermanently,
+			statusCode == http.StatusFound,
+			statusCode == http.StatusSeeOther,
+			statusCode == http.StatusTemporaryRedirect,
+			statusCode == http.StatusPermanentRedirect,
 			statusCode == http.StatusUnauthorized,
 			statusCode == http.StatusForbidden:
 			return fmt.Errorf("%w: status=%d: %w", biz.ErrCrawlerAuthentication, statusCode, err)

--- a/be-classlist/crawler/errors.go
+++ b/be-classlist/crawler/errors.go
@@ -1,0 +1,44 @@
+package crawler
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/asynccnu/ccnubox-be/be-classlist/biz"
+	"github.com/asynccnu/ccnubox-be/common/pkg/httpx"
+)
+
+// 分类HTTP响应的错误
+// 复用了httpx包的哨兵错误
+func classifyResponseError(resp *http.Response, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, httpx.ErrUnexpectedStatus) && resp != nil {
+		statusCode := resp.StatusCode
+		switch {
+		case statusCode >= http.StatusMultipleChoices && statusCode < http.StatusBadRequest,
+			statusCode == http.StatusUnauthorized,
+			statusCode == http.StatusForbidden:
+			return fmt.Errorf("%w: status=%d: %w", biz.ErrCrawlerAuthentication, statusCode, err)
+		case statusCode == http.StatusRequestTimeout,
+			statusCode == http.StatusTooEarly,
+			statusCode == http.StatusTooManyRequests,
+			statusCode >= http.StatusInternalServerError:
+			return fmt.Errorf("%w: status=%d: %w", biz.ErrCrawlerTemporary, statusCode, err)
+		default:
+			return fmt.Errorf("%w: status=%d: %w", biz.ErrCrawlerProtocol, statusCode, err)
+		}
+	}
+
+	if errors.Is(err, httpx.ErrBodyTooLarge) ||
+		errors.Is(err, httpx.ErrUnexpectedMediaType) ||
+		errors.Is(err, httpx.ErrInvalidResponse) {
+		return fmt.Errorf("%w: %w", biz.ErrCrawlerProtocol, err)
+	}
+
+	// Body 读取时的 EOF、连接重置等错误保留原类型，由 usecase 的 net.Error/io 错误分类处理。
+	return err
+}

--- a/be-classlist/events/consumer/consumer.go
+++ b/be-classlist/events/consumer/consumer.go
@@ -381,9 +381,9 @@ func (c *Consumer) Consume(topics []string, groupID string, handler sarama.Consu
 				return err
 			}
 			consecutiveFailures++
-			if consecutiveFailures >= maxImmediateRetryAttempts {
-				return err
-			}
+			// Consumer Group 的临时基础设施错误不能让后台消费者永久退出。
+			// 这里持续做有上限、可取消的退避重连；消息处理本身仍由
+			// handleWithRetry/processMessage 保持有限次数，避免 poison message 阻塞分区。
 			c.log.Errorf("consumer group %s session ended with temporary error, retrying in %v: attempt=%d err=%v",
 				groupID, backoff, consecutiveFailures, err)
 			if !sleepWithContext(c.cctx, backoff) {

--- a/be-classlist/events/consumer/consumer.go
+++ b/be-classlist/events/consumer/consumer.go
@@ -215,7 +215,13 @@ func NewConsumer(newClient ClientFactory, l logger.Logger) *Consumer {
 
 func (c *Consumer) Consume(topics []string, groupID string, handler sarama.ConsumerGroupHandler) error {
 	// ConsumerGroup 不共用 Client
+	if c.newClient == nil {
+		return ErrNilClient
+	}
 	client := c.newClient()
+	if client == nil {
+		return ErrNilClient
+	}
 	cg, err := c.newGroup(groupID, client)
 	if err != nil {
 		if closeErr := client.Close(); closeErr != nil {
@@ -251,6 +257,7 @@ func (c *Consumer) Close() {
 }
 
 var ErrInvalidGroupID = errors.New("the groupID is not allowed")
+var ErrNilClient = errors.New("kafka client factory returned nil")
 
 // classifyError 将 Kafka/Sarama 错误分类，用于 mq_failed_total 标签
 func classifyError(err error) string {

--- a/be-classlist/events/consumer/consumer.go
+++ b/be-classlist/events/consumer/consumer.go
@@ -132,13 +132,13 @@ func (c *DelaySendHandler) forwardMessage(ctx context.Context, msg *sarama.Consu
 
 // FuncConsumeHandler 消费真实 topic 消息并交付给应用
 type FuncConsumeHandler struct {
-	f             func(ctx context.Context, key []byte, value []byte)
+	f             func(ctx context.Context, key []byte, value []byte) error
 	log           logger.Logger
 	consumedTotal *prometheus.CounterVec
 	mqFailedTotal *prometheus.CounterVec
 }
 
-func NewFuncConsumeHandler(f func(ctx context.Context, key []byte, value []byte), l logger.Logger, m *metricsx.Metrics) FuncConsumeHandler {
+func NewFuncConsumeHandler(f func(ctx context.Context, key []byte, value []byte) error, l logger.Logger, m *metricsx.Metrics) FuncConsumeHandler {
 	return FuncConsumeHandler{
 		f:             f,
 		log:           l,
@@ -169,11 +169,20 @@ func (fc FuncConsumeHandler) ConsumeClaim(session sarama.ConsumerGroupSession, c
 		tlog := fc.log.WithContext(ctx)
 
 		tlog.Debugf("Message claimed: key:%s, value:%s", string(message.Key), string(message.Value))
-		fc.f(ctx, message.Key, message.Value)
-
-		if fc.consumedTotal != nil {
+		err := fc.f(ctx, message.Key, message.Value)
+		if err != nil {
+			tlog.Errorf("Error handling message: %v", err)
+			span.RecordError(err)
+			if fc.consumedTotal != nil {
+				fc.consumedTotal.WithLabelValues(message.Topic, "Error").Inc()
+			}
+			if fc.mqFailedTotal != nil {
+				fc.mqFailedTotal.WithLabelValues(message.Topic, classifyError(err)).Inc()
+			}
+		} else if fc.consumedTotal != nil {
 			fc.consumedTotal.WithLabelValues(message.Topic, "OK").Inc()
 		}
+		// 失败消息仍提交 offset；刷新逻辑会发布下一条延迟消息承接重试。
 		session.MarkMessage(message, "")
 
 		span.End()

--- a/be-classlist/events/consumer/consumer.go
+++ b/be-classlist/events/consumer/consumer.go
@@ -3,6 +3,7 @@ package consumer
 import (
 	"context"
 	"errors"
+	"net"
 	"sync"
 	"time"
 
@@ -62,6 +63,38 @@ func (c *DelaySendHandler) Cleanup(sarama.ConsumerGroupSession) error {
 
 func (c *DelaySendHandler) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
 	for message := range claim.Messages() {
+		if !c.processMessage(session, message) {
+			// session 已结束（rebalance 或关闭），当前消息未提交，下个 generation 会重新投递。
+			// 这里必须返回 nil：sarama 只把 ConsumeClaim 的错误交给 handleError，
+			// 并不会结束 session，返回错误只会让本分区在剩余 session 里静默停摆。
+			return nil
+		}
+		session.MarkMessage(message, "")
+	}
+	return nil
+}
+
+// processMessage 等待消息到期并转发，临时失败则做有限次原地退避重试。
+// 返回 false 表示 session 已结束，当前消息不得提交 offset。
+func (c *DelaySendHandler) processMessage(session sarama.ConsumerGroupSession, message *sarama.ConsumerMessage) bool {
+	// 未到期就原地等到期。分区内消息按投递时间有序，阻塞本分区正是延迟队列想要的语义。
+	for {
+		dur := time.Since(message.Timestamp)
+		if dur >= c.delayTime {
+			break
+		}
+		if !sleepWithContext(session.Context(), c.delayTime-dur) {
+			return false
+		}
+	}
+
+	// 严重滞后的消息直接丢弃，不再转发。
+	if c.delayTime > 0 && time.Since(message.Timestamp) >= 20*c.delayTime {
+		return true
+	}
+
+	backoff := initialRetryBackoff
+	for attempt := 1; ; attempt++ {
 		ctx := otel.GetTextMapPropagator().Extract(context.Background(), otelsarama.NewConsumerMessageCarrier(message))
 
 		tracer := otel.Tracer("delay-queue-consume")
@@ -70,30 +103,11 @@ func (c *DelaySendHandler) ConsumeClaim(session sarama.ConsumerGroupSession, cla
 		)
 
 		tlog := c.log.WithContext(ctx)
-		dur := time.Since(message.Timestamp)
+		tlog.Debugf("Message claimed: key:%s, value:%s, time_sub:%v",
+			string(message.Key), string(message.Value), time.Since(message.Timestamp))
 
-		tlog.Debugf("Message claimed: key:%s, value:%s, time_sub:%v", string(message.Key), string(message.Value), dur)
-
-		if dur >= c.delayTime {
-			if c.delayTime > 0 && dur >= 20*c.delayTime {
-				session.MarkMessage(message, "")
-				span.End()
-				continue
-			}
-
-			err := c.forwardMessage(ctx, message)
-			if err != nil {
-				tlog.Errorf("Error forwarding message: %s", string(message.Value))
-				if c.mqFailedTotal != nil {
-					c.mqFailedTotal.WithLabelValues(c.topic, classifyError(err)).Inc()
-				}
-				// 失败也要提交 offset, 否则 rebalance/重启后会无限重投同一条消息。
-				// 真正的重试/告警应该走独立的失败队列或外部告警通道, 不在消费循环里死磕。
-				session.MarkMessage(message, "")
-				span.End()
-				return nil
-			}
-
+		err := c.forwardMessage(ctx, message)
+		if err == nil {
 			// 消费计数
 			if c.producedTotal != nil {
 				c.producedTotal.WithLabelValues(c.topic, "OK").Inc()
@@ -101,17 +115,40 @@ func (c *DelaySendHandler) ConsumeClaim(session sarama.ConsumerGroupSession, cla
 			if c.consumedTotal != nil {
 				c.consumedTotal.WithLabelValues(c.delayTopic, "OK").Inc()
 			}
-
-			session.MarkMessage(message, "")
 			span.End()
-			continue
+			return true
 		}
 
+		tlog.Errorf("Error forwarding message: %s: %v", string(message.Value), err)
+		span.RecordError(err)
+		if c.mqFailedTotal != nil {
+			c.mqFailedTotal.WithLabelValues(c.topic, classifyError(err)).Inc()
+		}
+
+		// 保持原有行为：永久错误和未知错误记录后确认，避免毒消息永久阻塞分区。
+		if !isRetryableKafkaError(err) {
+			tlog.Errorf("Non-retryable forwarding error, acknowledging message: topic=%s partition=%d offset=%d err=%v",
+				message.Topic, message.Partition, message.Offset, err)
+			span.End()
+			return true
+		}
+		// 临时错误只做有限次原地重试；耗尽后仍按原有行为确认消息。
+		if attempt >= maxImmediateRetryAttempts {
+			tlog.Errorf("Forwarding retries exhausted, acknowledging message: topic=%s partition=%d offset=%d attempts=%d err=%v",
+				message.Topic, message.Partition, message.Offset, attempt, err)
+			span.End()
+			return true
+		}
+
+		tlog.Warnf("Retrying message forwarding in %v: topic=%s partition=%d offset=%d attempt=%d",
+			backoff, message.Topic, message.Partition, message.Offset, attempt)
 		span.End()
-		time.Sleep(time.Second)
-		return nil
+
+		if !sleepWithContext(session.Context(), backoff) {
+			return false
+		}
+		backoff = nextBackoff(backoff)
 	}
-	return nil
 }
 
 func (c *DelaySendHandler) forwardMessage(ctx context.Context, msg *sarama.ConsumerMessage) error {
@@ -132,13 +169,13 @@ func (c *DelaySendHandler) forwardMessage(ctx context.Context, msg *sarama.Consu
 
 // FuncConsumeHandler 消费真实 topic 消息并交付给应用
 type FuncConsumeHandler struct {
-	f             func(ctx context.Context, key []byte, value []byte) error
+	f             func(ctx context.Context, key []byte, value []byte) (ack bool, err error)
 	log           logger.Logger
 	consumedTotal *prometheus.CounterVec
 	mqFailedTotal *prometheus.CounterVec
 }
 
-func NewFuncConsumeHandler(f func(ctx context.Context, key []byte, value []byte) error, l logger.Logger, m *metricsx.Metrics) FuncConsumeHandler {
+func NewFuncConsumeHandler(f func(ctx context.Context, key []byte, value []byte) (ack bool, err error), l logger.Logger, m *metricsx.Metrics) FuncConsumeHandler {
 	return FuncConsumeHandler{
 		f:             f,
 		log:           l,
@@ -159,6 +196,20 @@ func (fc FuncConsumeHandler) Cleanup(sarama.ConsumerGroupSession) error {
 
 func (fc FuncConsumeHandler) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
 	for message := range claim.Messages() {
+		if !fc.handleWithRetry(session, message) {
+			return nil
+		}
+		// 业务失败也可以确认：例如下一条延迟重试已发布，或错误已判定为终态。
+		session.MarkMessage(message, "")
+	}
+	return nil
+}
+
+// handleWithRetry 对未确认消息做有限次原地重试。
+// 返回 false 表示 session 已结束，当前消息不得提交 offset。
+func (fc FuncConsumeHandler) handleWithRetry(session sarama.ConsumerGroupSession, message *sarama.ConsumerMessage) bool {
+	backoff := initialRetryBackoff
+	for attempt := 1; ; attempt++ {
 		ctx := otel.GetTextMapPropagator().Extract(context.Background(), otelsarama.NewConsumerMessageCarrier(message))
 
 		tracer := otel.Tracer("real-topic")
@@ -169,7 +220,10 @@ func (fc FuncConsumeHandler) ConsumeClaim(session sarama.ConsumerGroupSession, c
 		tlog := fc.log.WithContext(ctx)
 
 		tlog.Debugf("Message claimed: key:%s, value:%s", string(message.Key), string(message.Value))
-		err := fc.f(ctx, message.Key, message.Value)
+		ack, err := fc.f(ctx, message.Key, message.Value)
+		if !ack && err == nil {
+			err = errors.New("message requested retry without an error")
+		}
 		if err != nil {
 			tlog.Errorf("Error handling message: %v", err)
 			span.RecordError(err)
@@ -182,12 +236,87 @@ func (fc FuncConsumeHandler) ConsumeClaim(session sarama.ConsumerGroupSession, c
 		} else if fc.consumedTotal != nil {
 			fc.consumedTotal.WithLabelValues(message.Topic, "OK").Inc()
 		}
-		// 失败消息仍提交 offset；刷新逻辑会发布下一条延迟消息承接重试。
-		session.MarkMessage(message, "")
-
 		span.End()
+
+		if ack {
+			return true
+		}
+		// 保持原有行为：有限重试耗尽后确认消息，避免永久阻塞当前分区。
+		if attempt >= maxImmediateRetryAttempts {
+			tlog.Errorf("Message retries exhausted, acknowledging message: topic=%s partition=%d offset=%d attempts=%d err=%v",
+				message.Topic, message.Partition, message.Offset, attempt, err)
+			return true
+		}
+
+		tlog.Warnf("Message not acked, retrying in %v: topic=%s partition=%d offset=%d attempt=%d",
+			backoff, message.Topic, message.Partition, message.Offset, attempt)
+		if !sleepWithContext(session.Context(), backoff) {
+			return false
+		}
+		backoff = nextBackoff(backoff)
 	}
-	return nil
+}
+
+const maxImmediateRetryAttempts = 4
+
+var (
+	initialRetryBackoff = time.Second
+	maxRetryBackoff     = 30 * time.Second
+)
+
+// sleepWithContext 退避等待。返回 false 表示 ctx 已结束（rebalance 或关闭），
+// 调用方必须立即退出并且不得提交当前 offset。
+func sleepWithContext(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func nextBackoff(cur time.Duration) time.Duration {
+	next := cur * 2
+	if next > maxRetryBackoff {
+		return maxRetryBackoff
+	}
+	return next
+}
+
+// isRetryableKafkaError 只对白名单中的明确临时错误返回 true。
+// 永久错误和未知错误默认不重试，以保持原有的确认行为。
+func isRetryableKafkaError(err error) bool {
+	var producerErr *sarama.ProducerError
+	if errors.As(err, &producerErr) {
+		err = producerErr.Err
+	}
+
+	if errors.Is(err, sarama.ErrOutOfBrokers) ||
+		errors.Is(err, sarama.ErrLeaderNotAvailable) ||
+		errors.Is(err, sarama.ErrNotLeaderForPartition) ||
+		errors.Is(err, sarama.ErrRequestTimedOut) ||
+		errors.Is(err, sarama.ErrNotEnoughReplicas) ||
+		errors.Is(err, sarama.ErrNotEnoughReplicasAfterAppend) ||
+		errors.Is(err, sarama.ErrUnknownTopicOrPartition) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+func isRetryableConsumerGroupError(err error) bool {
+	return isRetryableKafkaError(err) ||
+		errors.Is(err, sarama.ErrNotCoordinatorForConsumer) ||
+		errors.Is(err, sarama.ErrConsumerCoordinatorNotAvailable) ||
+		errors.Is(err, sarama.ErrOffsetsLoadInProgress) ||
+		errors.Is(err, sarama.ErrRebalanceInProgress)
 }
 
 type Consumer struct {
@@ -239,13 +368,32 @@ func (c *Consumer) Consume(topics []string, groupID string, handler sarama.Consu
 		}
 	}()
 
+	backoff := initialRetryBackoff
+	consecutiveFailures := 0
 	for {
-		if err := cg.Consume(c.cctx, topics, handler); err != nil {
-			return err
-		}
+		err := cg.Consume(c.cctx, topics, handler)
 		if c.cctx.Err() != nil {
 			return c.cctx.Err()
 		}
+		if err != nil {
+			// 永久错误和未知错误保持原有行为，直接返回给调用方。
+			if !isRetryableConsumerGroupError(err) {
+				return err
+			}
+			consecutiveFailures++
+			if consecutiveFailures >= maxImmediateRetryAttempts {
+				return err
+			}
+			c.log.Errorf("consumer group %s session ended with temporary error, retrying in %v: attempt=%d err=%v",
+				groupID, backoff, consecutiveFailures, err)
+			if !sleepWithContext(c.cctx, backoff) {
+				return c.cctx.Err()
+			}
+			backoff = nextBackoff(backoff)
+			continue
+		}
+		backoff = initialRetryBackoff
+		consecutiveFailures = 0
 	}
 }
 
@@ -256,8 +404,10 @@ func (c *Consumer) Close() {
 	}
 }
 
-var ErrInvalidGroupID = errors.New("the groupID is not allowed")
-var ErrNilClient = errors.New("kafka client factory returned nil")
+var (
+	ErrInvalidGroupID = errors.New("the groupID is not allowed")
+	ErrNilClient      = errors.New("kafka client factory returned nil")
+)
 
 // classifyError 将 Kafka/Sarama 错误分类，用于 mq_failed_total 标签
 func classifyError(err error) string {

--- a/be-classlist/events/consumer/consumer.go
+++ b/be-classlist/events/consumer/consumer.go
@@ -184,26 +184,45 @@ func (fc FuncConsumeHandler) ConsumeClaim(session sarama.ConsumerGroupSession, c
 type Consumer struct {
 	cctx       context.Context
 	cancelFunc context.CancelFunc
-	client     sarama.Client
+	newClient  ClientFactory
+	newGroup   consumerGroupFactory
 	log        logger.Logger
 }
 
-func NewConsumer(client sarama.Client, l logger.Logger) *Consumer {
+type ClientFactory func() sarama.Client
+
+type consumerGroupFactory func(groupID string, client sarama.Client) (sarama.ConsumerGroup, error)
+
+func NewConsumer(newClient ClientFactory, l logger.Logger) *Consumer {
 	cctx, cancel := context.WithCancel(context.Background())
 	return &Consumer{
 		cctx:       cctx,
 		cancelFunc: cancel,
-		client:     client,
+		newClient:  newClient,
+		newGroup:   sarama.NewConsumerGroupFromClient,
 		log:        l,
 	}
 }
 
 func (c *Consumer) Consume(topics []string, groupID string, handler sarama.ConsumerGroupHandler) error {
-	cg, err := sarama.NewConsumerGroupFromClient(groupID, c.client)
+	// ConsumerGroup 不共用 Client
+	client := c.newClient()
+	cg, err := c.newGroup(groupID, client)
 	if err != nil {
+		if closeErr := client.Close(); closeErr != nil {
+			c.log.Errorf("Error closing Kafka client after consumer group creation failed: %v", closeErr)
+		}
 		return err
 	}
-	defer cg.Close()
+	defer func() {
+		// Client 生命周期比 ConsumerGroup 长
+		if err := cg.Close(); err != nil {
+			c.log.Errorf("Error closing consumer group %s: %v", groupID, err)
+		}
+		if err := client.Close(); err != nil {
+			c.log.Errorf("Error closing Kafka client for consumer group %s: %v", groupID, err)
+		}
+	}()
 
 	for {
 		if err := cg.Consume(c.cctx, topics, handler); err != nil {

--- a/be-classlist/events/delay/delay.go
+++ b/be-classlist/events/delay/delay.go
@@ -39,7 +39,7 @@ func NewDelayKafkaConfig() DelayKafkaConfig {
 	}
 }
 
-func NewDelayKafka(client sarama.Client, cf DelayKafkaConfig, l logger.Logger, m *metricsx.Metrics) (biz.DelayQueue, func(), error) {
+func NewDelayKafka(client sarama.Client, newConsumerClient consumer.ClientFactory, cf DelayKafkaConfig, l logger.Logger, m *metricsx.Metrics) (biz.DelayQueue, func(), error) {
 	dk := &DelayKafka{
 		delayTopic:   cf.DelayTopic,
 		realTopic:    cf.RealTopic,
@@ -57,7 +57,7 @@ func NewDelayKafka(client sarama.Client, cf DelayKafkaConfig, l logger.Logger, m
 	if err != nil {
 		return nil, nil, err
 	}
-	c := consumer.NewConsumer(client, l)
+	c := consumer.NewConsumer(newConsumerClient, l)
 
 	dk.p = p
 	dk.c = c

--- a/be-classlist/events/delay/delay.go
+++ b/be-classlist/events/delay/delay.go
@@ -80,7 +80,7 @@ func (d *DelayKafka) consumeDelay() error {
 	return d.c.Consume([]string{d.delayTopic}, d.proxyGroupID, d.delaySend)
 }
 
-func (d *DelayKafka) Consume(groupID string, f func(ctx context.Context, key []byte, value []byte) error) error {
+func (d *DelayKafka) Consume(groupID string, f func(ctx context.Context, key []byte, value []byte) (ack bool, err error)) error {
 	if groupID == d.proxyGroupID {
 		return consumer.ErrInvalidGroupID
 	}

--- a/be-classlist/events/delay/delay.go
+++ b/be-classlist/events/delay/delay.go
@@ -80,7 +80,7 @@ func (d *DelayKafka) consumeDelay() error {
 	return d.c.Consume([]string{d.delayTopic}, d.proxyGroupID, d.delaySend)
 }
 
-func (d *DelayKafka) Consume(groupID string, f func(ctx context.Context, key []byte, value []byte)) error {
+func (d *DelayKafka) Consume(groupID string, f func(ctx context.Context, key []byte, value []byte) error) error {
 	if groupID == d.proxyGroupID {
 		return consumer.ErrInvalidGroupID
 	}

--- a/be-classlist/events/producer/producer.go
+++ b/be-classlist/events/producer/producer.go
@@ -15,10 +15,15 @@ import (
 
 type Producer struct {
 	topic         string
-	kp            sarama.SyncProducer
+	kp            syncProducer
 	log           logger.Logger
 	producedTotal *prometheus.CounterVec
 	mqFailedTotal *prometheus.CounterVec
+}
+
+type syncProducer interface {
+	SendMessage(msg *sarama.ProducerMessage) (partition int32, offset int64, err error)
+	Close() error
 }
 
 func NewProducer(topic string, client sarama.Client, l logger.Logger, m *metricsx.Metrics) (*Producer, error) {
@@ -51,11 +56,26 @@ func (p *Producer) SendMessage(ctx context.Context, key, value []byte) error {
 		Timestamp: time.Now(),
 	}
 
-	_, _, err := p.kp.SendMessage(msg)
+	// 包装使用ctx
+	if err := ctx.Err(); err != nil {
+		p.recordFailure(err)
+		return err
+	}
+
+	resultCh := make(chan error, 1)
+	go func() {
+		_, _, err := p.kp.SendMessage(msg)
+		resultCh <- err
+	}()
+
+	var err error
+	select {
+	case err = <-resultCh:
+	case <-ctx.Done():
+		err = ctx.Err()
+	}
 	if err != nil {
-		if p.mqFailedTotal != nil {
-			p.mqFailedTotal.WithLabelValues(p.topic, classifyError(err)).Inc()
-		}
+		p.recordFailure(err)
 		return err
 	}
 	if p.producedTotal != nil {
@@ -63,6 +83,12 @@ func (p *Producer) SendMessage(ctx context.Context, key, value []byte) error {
 	}
 	tlog.Debugf("Produced message with key:%s, value:%s", string(key), string(value))
 	return nil
+}
+
+func (p *Producer) recordFailure(err error) {
+	if p.mqFailedTotal != nil {
+		p.mqFailedTotal.WithLabelValues(p.topic, classifyError(err)).Inc()
+	}
 }
 
 func (p *Producer) Close() {
@@ -91,6 +117,12 @@ func classifyError(err error) string {
 	}
 	if errors.Is(err, sarama.ErrInvalidTopic) {
 		return "invalid_topic"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "canceled"
 	}
 	return "produce_error"
 }

--- a/be-classlist/events/producer/producer.go
+++ b/be-classlist/events/producer/producer.go
@@ -62,19 +62,9 @@ func (p *Producer) SendMessage(ctx context.Context, key, value []byte) error {
 		return err
 	}
 
-	resultCh := make(chan error, 1)
-	go func() {
-		_, _, err := p.kp.SendMessage(msg)
-		resultCh <- err
-	}()
-
-	var err error
-	select {
-	case err = <-resultCh:
-	case <-ctx.Done():
-		err = ctx.Err()
-	}
+	_, _, err := p.kp.SendMessage(msg)
 	if err != nil {
+		span.RecordError(err)
 		p.recordFailure(err)
 		return err
 	}

--- a/be-classlist/go.mod
+++ b/be-classlist/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/asynccnu/ccnubox-be/common v0.0.0-20260308110957-82a74932722c
 	github.com/avast/retry-go v3.0.0+incompatible
+	github.com/go-sql-driver/mysql v1.8.1
 	github.com/google/wire v0.7.0
 	github.com/joho/godotenv v1.5.1
 	github.com/prometheus/client_golang v1.23.2
@@ -46,7 +47,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-playground/form/v4 v4.2.0 // indirect
-	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/be-classlist/ioc/ioc.go
+++ b/be-classlist/ioc/ioc.go
@@ -14,6 +14,7 @@ var ProviderSet = wire.NewSet(
 	InitProxyClient,
 	InitHttpProxyClient,
 	InitKafka,
+	InitKafkaConsumerClientFactory,
 	InitRedis,
 	InitMetrics,
 	InitMetricsServer,

--- a/be-classlist/ioc/kafka.go
+++ b/be-classlist/ioc/kafka.go
@@ -3,9 +3,16 @@ package ioc
 import (
 	"github.com/IBM/sarama"
 	"github.com/asynccnu/ccnubox-be/be-classlist/conf"
+	"github.com/asynccnu/ccnubox-be/be-classlist/events/consumer"
 	"github.com/asynccnu/ccnubox-be/common/bizpkg/infra"
 )
 
 func InitKafka(cfg *conf.InfraConf) sarama.Client {
 	return infra.InitKafka(cfg.Kafka)
+}
+
+func InitKafkaConsumerClientFactory(cfg *conf.InfraConf) consumer.ClientFactory {
+	return func() sarama.Client {
+		return infra.InitKafka(cfg.Kafka)
+	}
 }

--- a/be-classlist/ioc/kafka.go
+++ b/be-classlist/ioc/kafka.go
@@ -1,18 +1,36 @@
 package ioc
 
 import (
+	"time"
+
 	"github.com/IBM/sarama"
 	"github.com/asynccnu/ccnubox-be/be-classlist/conf"
 	"github.com/asynccnu/ccnubox-be/be-classlist/events/consumer"
 	"github.com/asynccnu/ccnubox-be/common/bizpkg/infra"
 )
 
+const (
+	kafkaDialTimeout     = 3 * time.Second
+	kafkaReadTimeout     = 5 * time.Second
+	kafkaWriteTimeout    = 5 * time.Second
+	kafkaProducerTimeout = 5 * time.Second
+	kafkaProducerRetries = 1
+)
+
 func InitKafka(cfg *conf.InfraConf) sarama.Client {
-	return infra.InitKafka(cfg.Kafka)
+	return infra.InitKafka(cfg.Kafka, configureKafkaProducer)
 }
 
 func InitKafkaConsumerClientFactory(cfg *conf.InfraConf) consumer.ClientFactory {
 	return func() sarama.Client {
 		return infra.InitKafka(cfg.Kafka)
 	}
+}
+
+func configureKafkaProducer(cfg *sarama.Config) {
+	cfg.Net.DialTimeout = kafkaDialTimeout
+	cfg.Net.ReadTimeout = kafkaReadTimeout
+	cfg.Net.WriteTimeout = kafkaWriteTimeout
+	cfg.Producer.Timeout = kafkaProducerTimeout
+	cfg.Producer.Retry.Max = kafkaProducerRetries
 }

--- a/be-classlist/repository/class.go
+++ b/be-classlist/repository/class.go
@@ -181,7 +181,7 @@ func (cla ClassRepo) UpdateClassNote(ctx context.Context, stuID, year, semester,
 
 // SaveClass 保存课程[删除原本的，添加新的，主要是为了防止感知不到原本的和新增的之间有差异]
 func (cla ClassRepo) SaveClass(ctx context.Context, stuID, year, semester string, classInfos []*bizModel.ClassInfoBO, scs []*bizModel.StudentCourseBO) error {
-	if (len(classInfos) == 0) != (len(scs) == 0) {
+	if len(classInfos) != len(scs) {
 		return errorx.Errorf("repo.class.SaveClass: inconsistent classInfos and scs lengths: %w", biz.ErrCrawlerProtocol)
 	}
 

--- a/be-classlist/repository/class.go
+++ b/be-classlist/repository/class.go
@@ -2,7 +2,6 @@ package repo
 
 import (
 	"context"
-	"errors"
 
 	"github.com/asynccnu/ccnubox-be/be-classlist/biz"
 	bizModel "github.com/asynccnu/ccnubox-be/be-classlist/biz/model"
@@ -182,8 +181,8 @@ func (cla ClassRepo) UpdateClassNote(ctx context.Context, stuID, year, semester,
 
 // SaveClass 保存课程[删除原本的，添加新的，主要是为了防止感知不到原本的和新增的之间有差异]
 func (cla ClassRepo) SaveClass(ctx context.Context, stuID, year, semester string, classInfos []*bizModel.ClassInfoBO, scs []*bizModel.StudentCourseBO) error {
-	if len(classInfos) == 0 || len(scs) == 0 {
-		return errorx.Errorf("repo.class.SaveClass: classInfos or scs is empty: %w", errors.New("empty input"))
+	if (len(classInfos) == 0) != (len(scs) == 0) {
+		return errorx.Errorf("repo.class.SaveClass: inconsistent classInfos and scs lengths: %w", biz.ErrCrawlerProtocol)
 	}
 
 	classInfosdo := make([]*repoModel.ClassInfo, 0, len(classInfos))

--- a/be-classlist/repository/dao/base.go
+++ b/be-classlist/repository/dao/base.go
@@ -26,10 +26,10 @@ func NewBaseDAO(db *gorm.DB, l logger.Logger) (BaseDAO, func(), error) {
 
 // mysql 写成私有字段，使得取数据库使用时必须得使用该逻辑，保证事务 db 一定能被取出
 func (dao *BaseDAO) GetDB(ctx context.Context) *gorm.DB {
-	tx, ok := ctx.Value(transaction.ContextTxKey{}).(*gorm.DB)
-	if ok && tx != nil {
-		return tx
+	db := dao.db
+	if tx, ok := ctx.Value(transaction.ContextTxKey{}).(*gorm.DB); ok && tx != nil {
+		db = tx
 	}
 
-	return dao.db.WithContext(ctx)
+	return db.WithContext(ctx)
 }

--- a/be-classlist/repository/dao/classInfo.go
+++ b/be-classlist/repository/dao/classInfo.go
@@ -25,7 +25,7 @@ func (c ClassInfoDAO) SaveClassInfosToDB(ctx context.Context, classInfos []*mode
 		return nil
 	}
 
-	db := c.GetDB(ctx).Table(model.ClassInfoTableName).WithContext(ctx)
+	db := c.GetDB(ctx).Table(model.ClassInfoTableName)
 	err := db.
 		Clauses(clause.OnConflict{
 			Columns: []clause.Column{{Name: "id"}},
@@ -50,7 +50,7 @@ func (c ClassInfoDAO) AddClassInfoToDB(ctx context.Context, classInfo *model.Cla
 	}
 
 	// 约定将事务 db 从 ctx 中取出来
-	db := c.GetDB(ctx).Table(model.ClassInfoTableName).WithContext(ctx)
+	db := c.GetDB(ctx).Table(model.ClassInfoTableName)
 	err := db.Clauses(clause.OnConflict{DoNothing: true}).Create(&classInfo).Error
 	if err != nil {
 		return errorx.Errorf("dao.classInfo.AddClassInfoToDB: classInfo=%+v: %w", classInfo, err)
@@ -66,7 +66,7 @@ func (c ClassInfoDAO) UpsertClassInfoToDB(ctx context.Context, classInfo *model.
 		return errorx.Errorf("dao.classInfo.UpsertClassInfoToDB: invalid day=%d, classInfo=%+v: %w", classInfo.Day, classInfo, biz.ErrInvalidParam)
 	}
 
-	db := c.GetDB(ctx).Table(model.ClassInfoTableName).WithContext(ctx)
+	db := c.GetDB(ctx).Table(model.ClassInfoTableName)
 	err := db.
 		Clauses(clause.OnConflict{
 			Columns: []clause.Column{{Name: "id"}},
@@ -98,7 +98,7 @@ func (c ClassInfoDAO) DeleteAddedClassInfos(ctx context.Context, classIDs []stri
 		return nil
 	}
 
-	db := c.GetDB(ctx).Table(model.ClassInfoTableName).WithContext(ctx)
+	db := c.GetDB(ctx).Table(model.ClassInfoTableName)
 	err := db.
 		Where("id IN ?", classIDs).
 		Delete(&model.ClassInfo{}).Error
@@ -109,7 +109,7 @@ func (c ClassInfoDAO) DeleteAddedClassInfos(ctx context.Context, classIDs []stri
 }
 
 func (c ClassInfoDAO) GetClassInfos(ctx context.Context, stuId, xnm, xqm string) ([]*model.ClassInfo, error) {
-	db := c.GetDB(ctx).WithContext(ctx)
+	db := c.GetDB(ctx)
 	cla := make([]*model.ClassInfo, 0)
 
 	err := db.Table(model.ClassInfoTableName).Select(fmt.Sprintf("%s.*", model.ClassInfoTableName)).
@@ -148,7 +148,7 @@ func (c ClassInfoDAO) GetAddedClassInfos(ctx context.Context, stuID, xnm, xqm st
 }
 
 func (c ClassInfoDAO) GetClassNatures(ctx context.Context, stuID string) ([]string, error) {
-	db := c.GetDB(ctx).WithContext(ctx)
+	db := c.GetDB(ctx)
 	natures := make([]string, 0)
 
 	subQuery := db.

--- a/be-classlist/repository/dao/jxb.go
+++ b/be-classlist/repository/dao/jxb.go
@@ -26,7 +26,7 @@ func (j *JxbDAO) SaveJxb(ctx context.Context, stuID string, jxbID []string) erro
 		return nil
 	}
 
-	db := j.GetDB(ctx).Table(model.JxbTableName).WithContext(ctx)
+	db := j.GetDB(ctx).Table(model.JxbTableName)
 	jxb := make([]model.Jxb, 0, len(jxbID))
 	for _, id := range jxbID {
 		jxb = append(jxb, model.Jxb{
@@ -43,7 +43,7 @@ func (j *JxbDAO) SaveJxb(ctx context.Context, stuID string, jxbID []string) erro
 
 func (j *JxbDAO) FindStuIdsByJxbId(ctx context.Context, jxbId string) ([]string, error) {
 	var stuIds []string
-	err := j.GetDB(ctx).Table(model.JxbTableName).WithContext(ctx).
+	err := j.GetDB(ctx).Table(model.JxbTableName).
 		Select("stu_id").Where("jxb_id = ?", jxbId).Find(&stuIds).Error
 	if err != nil {
 		return nil, errorx.Errorf("dao.jxb.FindStuIdsByJxbId: jxbId=%s, table=%s: %w", jxbId, model.JxbTableName, err)

--- a/be-classlist/repository/dao/refresh_log.go
+++ b/be-classlist/repository/dao/refresh_log.go
@@ -23,7 +23,7 @@ func NewRefreshLogDAO(base BaseDAO) *RefreshLogDAO {
 // GetLastRefreshTime 返回最后一次刷新成功的时间
 func (r *RefreshLogDAO) GetLastRefreshTime(ctx context.Context, stuID, year, semester, status string, beforeTime time.Time) (*time.Time, error) {
 	var refreshLog model.ClassRefreshLog
-	err := r.GetDB(ctx).WithContext(ctx).Table(model.ClassRefreshLogTableName).
+	err := r.GetDB(ctx).Table(model.ClassRefreshLogTableName).
 		Where("stu_id = ? and year = ? and semester = ? and updated_at < ? and status = ?", stuID, year, semester, beforeTime, status).
 		Order("updated_at desc").First(&refreshLog).Error
 	if err != nil {
@@ -52,7 +52,7 @@ func (r *RefreshLogDAO) InsertRefreshLog(ctx context.Context, stuID, year, semes
 }
 
 func (r *RefreshLogDAO) UpdateRefreshLogStatus(ctx context.Context, logID uint64, status string) error {
-	err := r.GetDB(ctx).WithContext(ctx).Table(model.ClassRefreshLogTableName).
+	err := r.GetDB(ctx).Table(model.ClassRefreshLogTableName).
 		Where("id = ?", logID).
 		Updates(map[string]interface{}{
 			"status":     status,
@@ -67,7 +67,7 @@ func (r *RefreshLogDAO) UpdateRefreshLogStatus(ctx context.Context, logID uint64
 // SearchNewestRefreshLog 查找在指定时间内的最新的一条记录
 func (r *RefreshLogDAO) SearchNewestRefreshLog(ctx context.Context, stuID, year, semester string, endTime time.Time) (*model.ClassRefreshLog, error) {
 	var refreshLog model.ClassRefreshLog
-	err := r.GetDB(ctx).WithContext(ctx).Table(model.ClassRefreshLogTableName).
+	err := r.GetDB(ctx).Table(model.ClassRefreshLogTableName).
 		Where("stu_id = ? and year = ? and semester = ? and updated_at < ?", stuID, year, semester, endTime).
 		Order("updated_at desc").First(&refreshLog).Error
 	if err != nil {
@@ -79,7 +79,7 @@ func (r *RefreshLogDAO) SearchNewestRefreshLog(ctx context.Context, stuID, year,
 // GetRefreshLogByID  查找指定ID的记录
 func (r *RefreshLogDAO) GetRefreshLogByID(ctx context.Context, logID uint64) (*model.ClassRefreshLog, error) {
 	var refreshLog model.ClassRefreshLog
-	err := r.GetDB(ctx).WithContext(ctx).Table(model.ClassRefreshLogTableName).
+	err := r.GetDB(ctx).Table(model.ClassRefreshLogTableName).
 		Where("id = ?", logID).First(&refreshLog).Error
 	if err != nil {
 		return nil, errorx.Errorf("dao.refreshLog.GetRefreshLogByID: logID=%d: %w", logID, err)
@@ -88,7 +88,7 @@ func (r *RefreshLogDAO) GetRefreshLogByID(ctx context.Context, logID uint64) (*m
 }
 
 func (r *RefreshLogDAO) createRefreshLog(ctx context.Context, refreshLog *model.ClassRefreshLog) error {
-	if err := r.GetDB(ctx).WithContext(ctx).Create(refreshLog).Error; err != nil {
+	if err := r.GetDB(ctx).Create(refreshLog).Error; err != nil {
 		return errorx.Errorf("dao.refreshLog.createRefreshLog: %w", err)
 	}
 	return nil

--- a/be-classlist/repository/dao/student_course.go
+++ b/be-classlist/repository/dao/student_course.go
@@ -39,7 +39,7 @@ func (s *StudentCourseDAO) GetClassMetaData(ctx context.Context, stuID, year, se
 
 	// 执行数据库查询
 	// 约定将事务 db 从上下文中取出
-	db := s.GetDB(ctx).Table(model.StudentCourseTableName).WithContext(ctx)
+	db := s.GetDB(ctx).Table(model.StudentCourseTableName)
 	err := db.Select("cla_id", "is_manually_added", "note").
 		Where("stu_id = ? AND year = ? AND semester = ? AND cla_id IN (?)", stuID, year, semester, claIds).
 		Find(&results).Error
@@ -70,7 +70,7 @@ func (s *StudentCourseDAO) GetClassNum(ctx context.Context, stuID, year, semeste
 
 func (s *StudentCourseDAO) AddedCourseExists(ctx context.Context, stuID, year, semester, classID string) bool {
 	var num int64
-	db := s.GetDB(ctx).Table(model.StudentCourseTableName).WithContext(ctx)
+	db := s.GetDB(ctx).Table(model.StudentCourseTableName)
 	err := db.Where("stu_id = ? AND year = ? AND semester = ? AND cla_id = ?", stuID, year, semester, classID).Count(&num).Error
 	if err != nil {
 		s.log.WithContext(ctx).Error("Mysql:count student_course failed",
@@ -91,7 +91,7 @@ func (s *StudentCourseDAO) SaveStudentAndCourseToDB(ctx context.Context, sc *mod
 		logh.Warn("insert student_course 0 data")
 		return nil
 	}
-	db := s.GetDB(ctx).Table(model.StudentCourseTableName).WithContext(ctx)
+	db := s.GetDB(ctx).Table(model.StudentCourseTableName)
 	err := db.Clauses(clause.OnConflict{DoNothing: true}).Create(sc).Error
 	if err != nil {
 		logh.Errorf("Mysql:create %v in %s failed: %v", sc, model.StudentCourseTableName, err)
@@ -107,7 +107,7 @@ func (s *StudentCourseDAO) SaveManyStudentAndCourseToDB(ctx context.Context, scs
 		return nil
 	}
 
-	db := s.GetDB(ctx).Table(model.StudentCourseTableName).WithContext(ctx)
+	db := s.GetDB(ctx).Table(model.StudentCourseTableName)
 
 	if err := db.Clauses(clause.OnConflict{DoNothing: true}).Create(scs).Error; err != nil {
 		logh.Errorf("Mysql:create %v in %s failed: %v", scs, model.StudentCourseTableName, err)
@@ -118,7 +118,7 @@ func (s *StudentCourseDAO) SaveManyStudentAndCourseToDB(ctx context.Context, scs
 
 func (s *StudentCourseDAO) DeleteStudentAndCourseByTimeFromDB(ctx context.Context, stuID, year, semester string) error {
 	logh := s.log.WithContext(ctx)
-	db := s.GetDB(ctx).Table(model.StudentCourseTableName).WithContext(ctx)
+	db := s.GetDB(ctx).Table(model.StudentCourseTableName)
 	// 注意:只删除非手动添加的课程，即官方课程
 	err := db.Where("year = ? AND semester = ? AND stu_id = ? AND is_manually_added = false", year, semester, stuID).Delete(&model.StudentCourse{}).Error
 	if err != nil {
@@ -134,7 +134,7 @@ func (s *StudentCourseDAO) DeleteAddedStudentCourses(ctx context.Context, stuID,
 	}
 
 	logh := s.log.WithContext(ctx)
-	db := s.GetDB(ctx).Table(model.StudentCourseTableName).WithContext(ctx)
+	db := s.GetDB(ctx).Table(model.StudentCourseTableName)
 	err := db.
 		Where("stu_id = ? AND year = ? AND semester = ? AND is_manually_added = true AND cla_id IN ?", stuID, year, semester, classIDs).
 		Delete(&model.StudentCourse{}).Error
@@ -147,7 +147,7 @@ func (s *StudentCourseDAO) DeleteAddedStudentCourses(ctx context.Context, stuID,
 
 func (s *StudentCourseDAO) UpdateCourseNote(ctx context.Context, stuID, year, semester, classID, note string) error {
 	logh := s.log.WithContext(ctx)
-	db := s.GetDB(ctx).Table(model.StudentCourseTableName).WithContext(ctx)
+	db := s.GetDB(ctx).Table(model.StudentCourseTableName)
 	err := db.
 		Where("stu_id = ? AND year = ? AND semester = ? AND cla_id = ?", stuID, year, semester, classID).
 		Update("note", note).Error

--- a/be-classlist/service/classlist.go
+++ b/be-classlist/service/classlist.go
@@ -57,15 +57,28 @@ func (s *ClassListService) GetClass(ctx context.Context, stuID, year, semester s
 
 	classes, lastTime, err := s.clu.GetClasses(ctx, stuID, year, semester, refresh)
 	if err != nil {
-		if errors.Is(err, biz.ErrInvalidParam) {
-			return nil, nil, ParamError(err)
-		}
-		if errors.Is(err, biz.ErrClassNotFound) {
-			return nil, nil, ClassNotFoundError(err)
-		}
-		return nil, nil, ClassFindError(err)
+		return nil, nil, mapGetClassError(err)
 	}
 	return classes, lastTime, nil
+}
+
+func mapGetClassError(err error) error {
+	switch {
+	case errors.Is(err, biz.ErrInvalidParam),
+		errors.Is(err, biz.ErrUnsupportedStudentType):
+		return ParamError(err)
+	case errors.Is(err, biz.ErrClassNotFound):
+		return ClassNotFoundError(err)
+	case errors.Is(err, biz.ErrCrawlerAuthentication):
+		return CCNULoginError(err)
+	case errors.Is(err, biz.ErrCrawlerProtocol),
+		errors.Is(err, biz.ErrCrawlerTemporary),
+		errors.Is(err, biz.ErrCrawlerEmptyResult),
+		errors.Is(err, biz.ErrClassRefreshPending):
+		return CrawlerError(err)
+	default:
+		return ClassFindError(err)
+	}
 }
 
 func (s *ClassListService) AddClass(ctx context.Context, stuID, name, durClass, where, teacher string, weeks int64, semester, year string, day int64, credit *float64) (id, msg string, err error) {

--- a/be-classlist/service/errors.go
+++ b/be-classlist/service/errors.go
@@ -16,4 +16,6 @@ var (
 	ClassAlreadyExistsError    = errorx.FormatErrorFunc(classlistv1.ErrorClassisexist("已有该课程"))
 	ConfigError                = errorx.FormatErrorFunc(classlistv1.ErrorConfigError("配置错误"))
 	ClassScheduleConflictError = errorx.FormatErrorFunc(classlistv1.ErrorErrClassScheduleConflict("添加课程时间冲突"))
+	CrawlerError               = errorx.FormatErrorFunc(classlistv1.ErrorCrawlerError("课程爬取失败"))
+	CCNULoginError             = errorx.FormatErrorFunc(classlistv1.ErrorCCNULoginError("教务系统登录态失效"))
 )

--- a/be-classlist/wire_gen.go
+++ b/be-classlist/wire_gen.go
@@ -49,9 +49,10 @@ func InitApp() (*App, func(), error) {
 	client2 := ioc.InitHttpProxyClient(proxyClient, infraConf, logger)
 	crawler3 := crawler.NewClassCrawler3(client2, logger)
 	saramaClient := ioc.InitKafka(infraConf)
+	clientFactory := ioc.InitKafkaConsumerClientFactory(infraConf)
 	delayKafkaConfig := delay.NewDelayKafkaConfig()
 	metrics := ioc.InitMetrics()
-	delayQueue, cleanup2, err := delay.NewDelayKafka(saramaClient, delayKafkaConfig, logger, metrics)
+	delayQueue, cleanup2, err := delay.NewDelayKafka(saramaClient, clientFactory, delayKafkaConfig, logger, metrics)
 	if err != nil {
 		cleanup()
 		return nil, nil, err

--- a/common/bizpkg/infra/kafka.go
+++ b/common/bizpkg/infra/kafka.go
@@ -7,7 +7,9 @@ import (
 	"github.com/asynccnu/ccnubox-be/common/bizpkg/conf"
 )
 
-func InitKafka(cfg *conf.KafkaConf) sarama.Client {
+type KafkaConfigOption func(*sarama.Config)
+
+func InitKafka(cfg *conf.KafkaConf, options ...KafkaConfigOption) sarama.Client {
 	saramaCfg := sarama.NewConfig()
 
 	saramaCfg.Net.SASL.Enable = true
@@ -17,6 +19,11 @@ func InitKafka(cfg *conf.KafkaConf) sarama.Client {
 
 	saramaCfg.Producer.Return.Successes = true
 	saramaCfg.Producer.Partitioner = sarama.NewConsistentCRCHashPartitioner
+	for _, option := range options {
+		if option != nil {
+			option(saramaCfg)
+		}
+	}
 
 	client, err := sarama.NewClient(cfg.Addrs, saramaCfg)
 	if err != nil {


### PR DESCRIPTION
## 内容
1. 新增重试的Attempts字段，防止无限重试
2. 区分是否能重试的错误
3. 增加爬虫Timeout
4. 给Producer写了ctx包装
5. 修复MQ部分的指标记录
6. 增加了协议层的错误展示

## !! 上线前检查
1. 新GroupID是否能消费topic **`be-classlist-real`**
2. Kafka是否能兼容新格式 **`refreshRetryMessage`**